### PR TITLE
API Monitoring Dashboard update

### DIFF
--- a/definitions/marts/ls_api_monitoring.sqlx
+++ b/definitions/marts/ls_api_monitoring.sqlx
@@ -31,8 +31,7 @@ WITH
   WHERE
     event_type = 'web_request'
     AND request_path LIKE '/api/v%'
-    AND request_path NOT LIKE '/api/v1/users%'
-    AND request_path NOT LIKE '/api/v1/ecf-users%')
+    AND request_path NOT LIKE ANY ('/api/v1/users%', '/api/v1/ecf-users%'))
 SELECT
   *,
   CASE


### PR DESCRIPTION
Pushing through changes to exclude PII from the API Monitoring Dashboard and link it to Dataform