### PR TITLE
Including employment_type in final output

### DIFF
--- a/definitions/marts/npq_enrolments.sqlx
+++ b/definitions/marts/npq_enrolments.sqlx
@@ -407,6 +407,7 @@ WITH
     updated_at,
     employer_name,
     employment_role,
+    employment_type,
     declaration_user_id,
     profile_user_id,
     training_status,


### PR DESCRIPTION
The employment_type field is included in the beginning portion of the code but isn't pulled through to the final output. It is needed to identify which users have gone down edge case routes and which routes they have taken.