### PR TITLE
Added the STI fields to participant_profiles and fixed (again) the NPQ outcome error code

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -641,6 +641,10 @@ dfeAnalyticsDataform({
       dataType: "date",
       description: ""
     }, {
+      keyName: "mentor_profile_id",
+      dataType: "string",
+      description: ""
+    }, {
       keyName: "notes",
       dataType: "string",
       description: ""
@@ -662,6 +666,14 @@ dfeAnalyticsDataform({
       description: ""
     }, {
       keyName: "schedule_id",
+      dataType: "string",
+      description: ""
+    }, {
+      keyName: "school_cohort_id",
+      dataType: "string",
+      description: ""
+    }, {
+      keyName: "school_id",
       dataType: "string",
       description: ""
     }, {

--- a/definitions/marts/ls_api_errors_npq_outcomes.sqlx
+++ b/definitions/marts/ls_api_errors_npq_outcomes.sqlx
@@ -59,4 +59,3 @@ INNER JOIN
   `ecf-bq.dataform.participant_declarations_latest_cpd` dec
 ON
   npqo.participant_declaration_id = dec.id
-ORDER BY days_error_open DESC


### PR DESCRIPTION
After Erica Porter fixed the problem on the ECF application side, our pipeline no longer crashes when we try to pull school_id, mentor_profile_id, and school_cohort_id into the participant_profiles table. I've now added these fields to our dataSchema.

Also, after fixing the partitionBy in the config section of the ls_api_errors_npq_outcomes to make sure it was partitioning by DATE, it turns out that having an ORDER BY statement at the end of a mart contradicts the partitionBy statement. So, I have removed the ORDER BY statement.