### PR TITLE
Temporarily filtering out the duplicate request_uuids

### DIFF
--- a/definitions/marts/ls_api_monitoring.sqlx
+++ b/definitions/marts/ls_api_monitoring.sqlx
@@ -31,8 +31,9 @@ WITH
   WHERE
     event_type = 'web_request'
     AND request_path LIKE '/api/v%'
-    AND request_path NOT LIKE ANY ('/api/v1/users%',
-      '/api/v1/ecf-users%','/api/v1/npq-applications.csv')),
+    AND request_uuid NOT IN ('5743acd834e004bea704e1c4a0065943',
+      'c1fdb72bd593d9eda54f8e95e9724884',
+      'edc376f322a4dc273b62997804695fb5')),
   request_response_fields AS (
   SELECT
     eep.request_uuid,


### PR DESCRIPTION
Changed from filtering out endpoints to filtering out the duplicate request_uuids themselves. Will be picking this up with Shahad in the New Year as this is a recurring issue.