### PR TITLE
Adding TRN to npq_enrolments

### DIFF
--- a/definitions/marts/bigquery_marts/npq/npq_enrolments.sqlx
+++ b/definitions/marts/bigquery_marts/npq/npq_enrolments.sqlx
@@ -378,6 +378,7 @@ WITH
   npq_gold_thread AS (
   SELECT
     DISTINCT application_ecf_id,
+    application_trn,
     trn_verified,
     trn_auto_verified,
     application_created_at,


### PR DESCRIPTION
Does what it says on the tin. Doing this so that we can more accurately track applicants on the NPQ Megasuite