### PR TITLE
Adding TRN so it can be shown on the dashboard

### DIFF
--- a/definitions/marts/looker_studio_marts/ecf/ls_induction_start_date.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_induction_start_date.sqlx
@@ -18,6 +18,7 @@ WITH
   SELECT
     ecfid.user_id,
     ecfid.participant_profile_id,
+    ecfid.trn,
     'ECT' AS participant_type_short,
     ecfid.cohort,
     ecfid.schedule_identifier,


### PR DESCRIPTION
Adding TRN to ls_induction_start_date so I can add it to the Appropriate Body page of the dashboard. This will help stakeholders more easily identify the relevant participant