### PR TITLE
npq_contract_management and financial statement cohort to self-serve declerations

### DIFF
--- a/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
@@ -41,11 +41,11 @@ WITH
     event_type = 'web_request'
     AND user_id IS NOT NULL
     AND request_path LIKE '/api/v%'
-    AND request_uuid NOT IN ('5743acd834e004bea704e1c4a0065943',
-      'c1fdb72bd593d9eda54f8e95e9724884',
-      'edc376f322a4dc273b62997804695fb5',
+    AND request_uuid NOT IN ('edc376f322a4dc273b62997804695fb5',
+      '13f9f767fabfcb2cafc16f366b72660e',
       '3b0872b43cd564d2133dbbff6fa1a4cf',
-      '13f9f767fabfcb2cafc16f366b72660e')),
+      'ad6a40fda446b96f3212cdb57d2e98e6',
+      'c1fdb72bd593d9eda54f8e95e972')),
   request_response_fields AS (
   SELECT
     eep.request_uuid,

--- a/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
@@ -45,7 +45,7 @@ WITH
       '13f9f767fabfcb2cafc16f366b72660e',
       '3b0872b43cd564d2133dbbff6fa1a4cf',
       'ad6a40fda446b96f3212cdb57d2e98e6',
-      'c1fdb72bd593d9eda54f8e95e972')),
+      'c1fdb72bd593d9eda54f8e95e9724884')),
   request_response_fields AS (
   SELECT
     eep.request_uuid,

--- a/definitions/marts/looker_studio_marts/ls_declarations_provider_names.sqlx
+++ b/definitions/marts/looker_studio_marts/ls_declarations_provider_names.sqlx
@@ -34,16 +34,34 @@ config {
         last_streamed_event_type: "Whether the most recent event was this entity being imported or updated.",
         cohort: "Participant's cohort from either npq_enrolments or ecf_indcutions_dedupe.",
         schedule_identifier: "Participant's schedule from either npq_enrolments or ecf_indcutions_dedupe.",
+        statement_cohort: "Cohort from the financial statement a declaration is stored against.",
         cpd_lp_name: "Name of Lead Provider for NPQ or ECF course",
         cpd_dp_name: "Name of Delivery Partner for ECF course",
         programme: "Shortening of 'type'. Says if it belongs to either the ECF or NPQ programme."
     }
 }
 
+WITH
+  statement_information AS (
+  /*This section pulls together statement info for all declarations from the tables statement_line_items and statements and gives the cohort associated with the statement that each declaration was made against*/
+  SELECT
+    DISTINCT stat_li.participant_declaration_id,
+    cohort.start_year AS statement_cohort
+  FROM
+    `dataform.statement_line_items_latest_cpd` stat_li
+  LEFT JOIN
+    `dataform.statements_latest_cpd` stat
+  ON
+    stat_li.statement_id=stat.id
+  LEFT JOIN
+    `dataform.cohorts_latest_cpd` cohort
+  ON
+    stat.cohort_id=cohort.id)
 SELECT
   dec.*,
   COALESCE(ecfid.cohort,npqe.cohort) AS cohort,
   COALESCE(ecfid.schedule_identifier,npqe.schedule_identifier) AS schedule_identifier,
+  state_info.statement_cohort,
   COALESCE(lpl.name,npqlpl.name) AS cpd_lp_name,
   dpl.name AS cpd_dp_name,
   CASE
@@ -63,6 +81,10 @@ LEFT JOIN
   ${ref("npq_enrolments")} npqe
 ON
   dec.participant_profile_id = npqe.application_ecf_id
+LEFT JOIN
+  statement_information state_info
+ON
+  dec.id=state_info.participant_declaration_id
 LEFT JOIN
   ${ref("lead_providers_latest_cpd")} lpl
 USING

--- a/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
@@ -58,7 +58,7 @@ WITH
       ELSE
       NULL
     END
-      ) AS acceptanced_applications,
+      ) AS accepted_applications,
     COUNT(DISTINCT
       CASE
         WHEN funding_choice IS NULL AND application_status = 'pending' THEN application_ecf_id

--- a/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
@@ -7,101 +7,93 @@ config {
         partitionBy: "",
         clusterBy: ["provider_name", "short_course_name"]
     },
-    description: "This mart creates a table that outlines the number of NPQ Outcomes that have been sent to the TRA but have failed to be verified. It sits in the CPD - API Monitoring dashboard.",
+    description: "THIS IS CURRENTLY A PROOF OF CONCEPT. This mart is made to help out NPQ Contract Managers with Lead Provider conversations. It creates a table that outlines the number DfE-funded applications, acceptance rates, starts, and targets for each Lead Provider and their courses.",
     columns: {
-        participant_outcome_id: "ID of each participant's outcome",
-        latest_outcome_sent: "Timestamp of when a participant's most recent outcome was sent over the API.",
-        latest_state: "The state of a participant's most recent outcome. In this table, all states should be 'passed'",
-        declaration_id: "ID of the 'completed' declaration associated with the participant's outcome.",
-        user_id: "The participant's user_id stored against their 'completed' declaration",
-        error_message: "The error code and reason why the outcome couldn't be processed.",
-        days_error_open: "How long since the error was raised. Calculated by finding the difference between the current timestamp and the created_at field from participant_outcome_api_requests_latest_cpd"
+        row_number_id: "ID of row number"
     }
 }
 
 WITH
-  full_course_counts_and_targets AS (
-  WITH
-    lead_provider_targets AS (
-    SELECT
-      lead_provider,
-      course,
-      TARGET
-    FROM
-      `ecf-bq.static_tables.npq_lead_provider_course_targets`
-    WHERE
-      academic_year = 'AY23-24'
-    ORDER BY
-      lead_provider ASC,
-      course ASC),
-    lead_provider_intake AS (
-    SELECT
-      provider_name,
-      CASE
-        WHEN course_name = 'NPQ Leading Literacy (NPQLL)' THEN 'NPQLL'
-        WHEN course_name = 'NPQ for Headship (NPQH)' THEN 'NPQH'
-        WHEN course_name = 'NPQ Early Years Leadership (NPQEYL)' THEN 'NPQEYL'
-        WHEN course_name = 'NPQ Leading Teacher Development (NPQLTD)' THEN 'NPQLTD'
-        WHEN course_name = 'NPQ Leading Primary Mathematics (NPQLPM)' THEN 'NPQLPM'
-        WHEN course_name = 'Additional Support Offer for new headteachers' THEN 'EHCO'
-        WHEN course_name = 'NPQ for Senior Leadership (NPQSL)' THEN 'NPQSL'
-        WHEN course_name = 'NPQ Leading Behaviour and Culture (NPQLBC)' THEN 'NPQLBC'
-        WHEN course_name = 'The Early Headship Coaching Offer' THEN 'EHCO'
-        WHEN course_name = 'NPQ Leading Teaching (NPQLT)' THEN 'NPQLT'
-        WHEN course_name = 'NPQ for Executive Leadership (NPQEL)' THEN 'NPQEL'
-      ELSE
-      course_name
-    END
-      AS short_course_name,
-      COUNT(DISTINCT application_ecf_id) AS registrations,
-      COUNT( DISTINCT
-        CASE
-          WHEN application_status = 'accepted' THEN application_ecf_id
-        ELSE
-        NULL
-      END
-        ) / COUNT(DISTINCT application_ecf_id) AS acceptance_rate,
-        COUNT( DISTINCT
-        CASE
-          WHEN application_status = 'pending' THEN application_ecf_id
-        ELSE
-        NULL
-      END
-        ) / COUNT(DISTINCT application_ecf_id) AS pending_rate,
-        COUNT( DISTINCT
-        CASE
-          WHEN application_status = 'rejected' THEN application_ecf_id
-        ELSE
-        NULL
-      END
-        ) / COUNT(DISTINCT application_ecf_id) AS rejected_rate,
-      COUNT(funded_start_declaration) AS starts
-    FROM
-      ${ref("npq_enrolments")}
-    WHERE cohort = 2023
-    GROUP BY
-      provider_name,
-      short_course_name
-    ORDER BY
-      provider_name ASC,
-      short_course_name ASC)
+  lead_provider_targets AS (
   SELECT
-    intake.*,
-    targets.target,
-    targets.target-intake.registrations AS registration_remainder,
-    targets.target-intake.starts AS start_remainder
+    lead_provider,
+    course,
+    TARGET
   FROM
-    lead_provider_intake intake
-  LEFT JOIN
-    lead_provider_targets targets
-  ON
-    intake.provider_name = targets.lead_provider
-    AND intake.short_course_name = targets.course
+    `ecf-bq.static_tables.npq_lead_provider_course_targets`
+  WHERE
+    academic_year = 'AY23-24'
+  ORDER BY
+    lead_provider ASC,
+    course ASC),
+  lead_provider_intake AS (
+  SELECT
+    provider_name,
+    CASE
+      WHEN course_name = 'NPQ Leading Literacy (NPQLL)' THEN 'NPQLL'
+      WHEN course_name = 'NPQ for Headship (NPQH)' THEN 'NPQH'
+      WHEN course_name = 'NPQ Early Years Leadership (NPQEYL)' THEN 'NPQEYL'
+      WHEN course_name = 'NPQ Leading Teacher Development (NPQLTD)' THEN 'NPQLTD'
+      WHEN course_name = 'NPQ Leading Primary Mathematics (NPQLPM)' THEN 'NPQLPM'
+      WHEN course_name = 'Additional Support Offer for new headteachers' THEN 'EHCO'
+      WHEN course_name = 'NPQ for Senior Leadership (NPQSL)' THEN 'NPQSL'
+      WHEN course_name = 'NPQ Leading Behaviour and Culture (NPQLBC)' THEN 'NPQLBC'
+      WHEN course_name = 'The Early Headship Coaching Offer' THEN 'EHCO'
+      WHEN course_name = 'NPQ Leading Teaching (NPQLT)' THEN 'NPQLT'
+      WHEN course_name = 'NPQ for Executive Leadership (NPQEL)' THEN 'NPQEL'
+    ELSE
+    course_name
+  END
+    AS short_course_name,
+    COUNT(DISTINCT
+      CASE
+        WHEN funding_choice IS NULL THEN application_ecf_id
+      ELSE
+      NULL
+    END
+      ) AS applications,
+    COUNT(DISTINCT
+      CASE
+        WHEN funding_choice IS NULL AND application_status = 'accepted' THEN application_ecf_id
+      ELSE
+      NULL
+    END
+      ) AS acceptanced_applications,
+    COUNT(DISTINCT
+      CASE
+        WHEN funding_choice IS NULL AND application_status = 'pending' THEN application_ecf_id
+      ELSE
+      NULL
+    END
+      ) AS pending_applications,
+    COUNT(DISTINCT
+      CASE
+        WHEN funding_choice IS NULL AND application_status = 'rejected' THEN application_ecf_id
+      ELSE
+      NULL
+    END
+      ) AS rejected_applications,
+    COUNT(funded_start_declaration) AS starts
+  FROM
+    ${ref("npq_enrolments")}
+  WHERE
+    cohort = 2023
+  GROUP BY
+    provider_name,
+    short_course_name
   ORDER BY
     provider_name ASC,
     short_course_name ASC)
 SELECT
-  (ROW_NUMBER() OVER()) AS row_number_id,
-  *
+  intake.*,
+  targets.target,
+  targets.target-intake.applications AS applications_remainder,
+  targets.target-intake.starts AS starts_remainder,
+  (ROW_NUMBER() OVER()) AS row_number_id
 FROM
-  full_course_counts_and_targets
+  lead_provider_intake intake
+LEFT JOIN
+  lead_provider_targets targets
+ON
+  intake.provider_name = targets.lead_provider
+  AND intake.short_course_name = targets.course

--- a/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
@@ -1,0 +1,107 @@
+config {
+    type: "table",
+    assertions: {
+        uniqueKey: ["row_number_id"]
+    },
+    bigquery: {
+        partitionBy: "",
+        clusterBy: ["provider_name", "short_course_name"]
+    },
+    description: "This mart creates a table that outlines the number of NPQ Outcomes that have been sent to the TRA but have failed to be verified. It sits in the CPD - API Monitoring dashboard.",
+    columns: {
+        participant_outcome_id: "ID of each participant's outcome",
+        latest_outcome_sent: "Timestamp of when a participant's most recent outcome was sent over the API.",
+        latest_state: "The state of a participant's most recent outcome. In this table, all states should be 'passed'",
+        declaration_id: "ID of the 'completed' declaration associated with the participant's outcome.",
+        user_id: "The participant's user_id stored against their 'completed' declaration",
+        error_message: "The error code and reason why the outcome couldn't be processed.",
+        days_error_open: "How long since the error was raised. Calculated by finding the difference between the current timestamp and the created_at field from participant_outcome_api_requests_latest_cpd"
+    }
+}
+
+WITH
+  full_course_counts_and_targets AS (
+  WITH
+    lead_provider_targets AS (
+    SELECT
+      lead_provider,
+      course,
+      TARGET
+    FROM
+      `ecf-bq.static_tables.npq_lead_provider_course_targets`
+    WHERE
+      academic_year = 'AY23-24'
+    ORDER BY
+      lead_provider ASC,
+      course ASC),
+    lead_provider_intake AS (
+    SELECT
+      provider_name,
+      CASE
+        WHEN course_name = 'NPQ Leading Literacy (NPQLL)' THEN 'NPQLL'
+        WHEN course_name = 'NPQ for Headship (NPQH)' THEN 'NPQH'
+        WHEN course_name = 'NPQ Early Years Leadership (NPQEYL)' THEN 'NPQEYL'
+        WHEN course_name = 'NPQ Leading Teacher Development (NPQLTD)' THEN 'NPQLTD'
+        WHEN course_name = 'NPQ Leading Primary Mathematics (NPQLPM)' THEN 'NPQLPM'
+        WHEN course_name = 'Additional Support Offer for new headteachers' THEN 'EHCO'
+        WHEN course_name = 'NPQ for Senior Leadership (NPQSL)' THEN 'NPQSL'
+        WHEN course_name = 'NPQ Leading Behaviour and Culture (NPQLBC)' THEN 'NPQLBC'
+        WHEN course_name = 'The Early Headship Coaching Offer' THEN 'EHCO'
+        WHEN course_name = 'NPQ Leading Teaching (NPQLT)' THEN 'NPQLT'
+        WHEN course_name = 'NPQ for Executive Leadership (NPQEL)' THEN 'NPQEL'
+      ELSE
+      course_name
+    END
+      AS short_course_name,
+      COUNT(DISTINCT application_ecf_id) AS registrations,
+      COUNT( DISTINCT
+        CASE
+          WHEN application_status = 'accepted' THEN application_ecf_id
+        ELSE
+        NULL
+      END
+        ) / COUNT(DISTINCT application_ecf_id) AS acceptance_rate,
+        COUNT( DISTINCT
+        CASE
+          WHEN application_status = 'pending' THEN application_ecf_id
+        ELSE
+        NULL
+      END
+        ) / COUNT(DISTINCT application_ecf_id) AS pending_rate,
+        COUNT( DISTINCT
+        CASE
+          WHEN application_status = 'rejected' THEN application_ecf_id
+        ELSE
+        NULL
+      END
+        ) / COUNT(DISTINCT application_ecf_id) AS rejected_rate,
+      COUNT(funded_start_declaration) AS starts
+    FROM
+      ${ref("npq_enrolments")}
+    WHERE cohort = 2023
+    GROUP BY
+      provider_name,
+      short_course_name
+    ORDER BY
+      provider_name ASC,
+      short_course_name ASC)
+  SELECT
+    intake.*,
+    targets.target,
+    targets.target-intake.registrations AS registration_remainder,
+    targets.target-intake.starts AS start_remainder
+  FROM
+    lead_provider_intake intake
+  LEFT JOIN
+    lead_provider_targets targets
+  ON
+    intake.provider_name = targets.lead_provider
+    AND intake.short_course_name = targets.course
+  ORDER BY
+    provider_name ASC,
+    short_course_name ASC)
+SELECT
+  (ROW_NUMBER() OVER()) AS row_number_id,
+  *
+FROM
+  full_course_counts_and_targets


### PR DESCRIPTION
**ls_npq_contract_management**
The npq_contract_management table is currently a proof of concept and not the final product, but it's included in this pull request so that everyone has access to it to make changes if needed.

**ls_declarations_provider_names**
Adding the financial statement cohort to the self-serve declarations has highlighted something we were already aware of: some declarations have been clawed back in a different cohort to the one they were paid in (Nathan mentions it in [this Slack message](https://ukgovernmentdfe.slack.com/archives/C055BDP51BN/p1712312287193599)).

This causes duplicates in the declaration ID field and therefore the uniqueKey Dataform assertion fails. This means the pipeline will appear to fail until these clawed_back declarations are resolved, but having the statement cohort in this table is important for other cohort correction checks.