### PR TITLE
Adding Eligibility Static File to Inductions

### DIFF
--- a/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
@@ -169,7 +169,7 @@ FROM
     ecf_induction_records.updated_at,
     completion_date,
     induction_programme_details.cohort_id,
-    user_id,
+    ecf_participant_profiles.user_id,
     participant_type,
     induction_record_created_at,
     induction_programme_details.partnership_id,
@@ -193,7 +193,8 @@ FROM
     ELSE
     ecf_partners.delivery_partner_name
   END
-    AS delivery_partner_name
+    AS delivery_partner_name,
+    eligible_for_funding,
     -- trn_validated,
     -- trn_validated_reason,
     -- manual_validation_required,
@@ -224,7 +225,11 @@ FROM
   LEFT JOIN
     `ecf-bq.dataform.ecf_partnerships` ecf_partners
   ON
-    induction_programme_details.partnership_id = ecf_partners.partnership_id)
+    induction_programme_details.partnership_id = ecf_partners.partnership_id
+  LEFT JOIN
+    `ecf-bq.static_tables.ecf_eligibility_statuses_20_02_24` ecf_eligibility
+  ON
+    ecf_induction_records.participant_profile_id = ecf_eligibility.participant_profile_id)
 SELECT
   *
 FROM


### PR DESCRIPTION
As a dummy field, adding the eligibility statuses from the static file we received from Peter. When table begins streaming through with up to date eligibility statuses, will swap over to the streamed through table. 