### PR TITLE
Updating the ls_npq_contract_management table

### DIFF
--- a/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
@@ -30,39 +30,40 @@ WITH
   SELECT
     provider_name,
     short_course_name,
+    COUNT(DISTINCT application_ecf_id) AS applications,
     COUNT(DISTINCT
       CASE
-        WHEN funding_choice IS NULL THEN application_ecf_id
-      ELSE
-      NULL
-    END
-      ) AS applications,
-    COUNT(DISTINCT
-      CASE
-        WHEN funding_choice IS NULL AND application_status = 'accepted' THEN application_ecf_id
+        WHEN application_status = 'accepted' THEN application_ecf_id
       ELSE
       NULL
     END
       ) AS accepted_applications,
     COUNT(DISTINCT
       CASE
-        WHEN funding_choice IS NULL AND application_status = 'pending' THEN application_ecf_id
+        WHEN application_status = 'pending' THEN application_ecf_id
       ELSE
       NULL
     END
       ) AS pending_applications,
     COUNT(DISTINCT
       CASE
-        WHEN funding_choice IS NULL AND application_status = 'rejected' THEN application_ecf_id
+        WHEN application_status = 'rejected' THEN application_ecf_id
       ELSE
       NULL
     END
       ) AS rejected_applications,
-    COUNT(funded_start_declaration) AS starts
+    COUNT(DISTINCT
+      CASE
+        WHEN funded_start_declaration IS TRUE THEN application_ecf_id
+      ELSE
+      NULL
+    END
+      ) AS starts
   FROM
     ${ref("npq_enrolments")}
   WHERE
     cohort = 2023
+    AND funding_choice IS NULL
   GROUP BY
     provider_name,
     short_course_name


### PR DESCRIPTION
Realised there was a simpler way of filtering for DfE-funded applications and that I hadn't been counting only TRUE funded start declarations which wasn't correct