### PR TITLE
Removing no longer relevant declarations

### DIFF
--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_cohort_corruption_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_cohort_corruption_checker.sqlx
@@ -40,9 +40,7 @@ config {
 }
 
 WITH
-  full_cohort_checker_output AS (
-  WITH
-    full_declaration_milestone_table AS (
+  full_declaration_milestone_table AS (
     /*This section creates a list of all submitted/eligible/payable/paid declarations for a participant, pulls in details from their current induction record, and then joins on the two static tables ecf_schedule_milestone_mapping and ecf_schedule_milestone_mapping_condensed to later make comparisons against the declaration_date of each participant*/
     SELECT
       dec_cpd.id AS declaration_id,
@@ -104,7 +102,7 @@ WITH
         'eligible',
         'payable',
         'paid')),
-    statement_information AS (
+  statement_information AS (
     /*This section pulls together statement info for all declarations from the tables statement_line_items and statements and gives the cohort associated with the statement that each declaration was made against*/
     SELECT
       stat_li.participant_declaration_id,
@@ -129,7 +127,7 @@ WITH
       stat.cohort_id=cohort.id
     WHERE
       stat.type LIKE '%ECF%'),
-    statement_cohort_checks AS (
+  statement_cohort_checks AS (
     SELECT
       fdmt.*,
       /*This CASE statement finds how far away a declaration is from its relevant declaration milestone window, as defined in the table ecf_schedule_milestone_mapping. Since a declaration can be on either side of the declaration window, the CASE statement calculates the greatest difference.*/
@@ -159,90 +157,60 @@ WITH
     LEFT JOIN
       statement_information si
     ON
-      fdmt.declaration_id=si.participant_declaration_id)
-  SELECT
-    *,
-    CASE /*This CASE statement works out which (if any) of the checks a declaration belongs to, either the financial statement cohort check or comparing declaration date check. Declarations can belong to one or both of the checks, and we're also pulling together all of a participant's declarations, hence the need for the NULL ending.*/
-      WHEN statement_cohort <> cohort AND (suggested_cohort_from_declaration <> cohort 
-    AND ((schedule_identifier LIKE 'ecf-standard%'
-        AND ((declaration_type = 'started'
-            AND (dec_date_short NOT BETWEEN started_dec_start_date
-              AND started_dec_milestone_date))
-          OR (declaration_type = 'retained-1'
-            AND (dec_date_short NOT BETWEEN ret1_dec_start_date
-              AND ret1_dec_milestone_date))
-          OR (declaration_type = 'retained-2'
-            AND (dec_date_short NOT BETWEEN ret2_dec_start_date
-              AND ret2_dec_milestone_date))
-          OR (declaration_type = 'retained-3'
-            AND (dec_date_short NOT BETWEEN ret3_dec_start_date
-              AND ret3_dec_milestone_date))
-          OR (declaration_type = 'retained-4'
-            AND (dec_date_short NOT BETWEEN ret4_dec_start_date
-              AND ret4_dec_milestone_date))
-          OR (declaration_type = 'completed'
-            AND (dec_date_short NOT BETWEEN completed_dec_start_date
-              AND completed_dec_milestone_date))))
-      OR (schedule_identifier LIKE ANY ('ecf-extended%',
-          'ecf-reduced%',
-          'ecf-replacement%')
-        AND ((declaration_type = 'started'
-            AND dec_date_short < started_dec_start_date)
-          OR (declaration_type = 'retained-1'
-            AND dec_date_short < ret1_dec_start_date)
-          OR (declaration_type = 'retained-2'
-            AND dec_date_short < ret2_dec_start_date)
-          OR (declaration_type = 'retained-3'
-            AND dec_date_short < ret3_dec_start_date)
-          OR (declaration_type = 'retained-4'
-            AND dec_date_short < ret4_dec_start_date)
-          OR (declaration_type = 'completed'
-            AND dec_date_short < completed_dec_start_date))))) THEN "in both checks"
-      WHEN suggested_cohort_from_declaration <> cohort
-    AND ((schedule_identifier LIKE 'ecf-standard%'
-        AND ((declaration_type = 'started'
-            AND (dec_date_short NOT BETWEEN started_dec_start_date
-              AND started_dec_milestone_date))
-          OR (declaration_type = 'retained-1'
-            AND (dec_date_short NOT BETWEEN ret1_dec_start_date
-              AND ret1_dec_milestone_date))
-          OR (declaration_type = 'retained-2'
-            AND (dec_date_short NOT BETWEEN ret2_dec_start_date
-              AND ret2_dec_milestone_date))
-          OR (declaration_type = 'retained-3'
-            AND (dec_date_short NOT BETWEEN ret3_dec_start_date
-              AND ret3_dec_milestone_date))
-          OR (declaration_type = 'retained-4'
-            AND (dec_date_short NOT BETWEEN ret4_dec_start_date
-              AND ret4_dec_milestone_date))
-          OR (declaration_type = 'completed'
-            AND (dec_date_short NOT BETWEEN completed_dec_start_date
-              AND completed_dec_milestone_date))))
-      OR (schedule_identifier LIKE ANY ('ecf-extended%',
-          'ecf-reduced%',
-          'ecf-replacement%')
-        AND ((declaration_type = 'started'
-            AND dec_date_short < started_dec_start_date)
-          OR (declaration_type = 'retained-1'
-            AND dec_date_short < ret1_dec_start_date)
-          OR (declaration_type = 'retained-2'
-            AND dec_date_short < ret2_dec_start_date)
-          OR (declaration_type = 'retained-3'
-            AND dec_date_short < ret3_dec_start_date)
-          OR (declaration_type = 'retained-4'
-            AND dec_date_short < ret4_dec_start_date)
-          OR (declaration_type = 'completed'
-            AND dec_date_short < completed_dec_start_date)))) THEN "declaration date check"
-      WHEN statement_cohort <> cohort THEN "statement check"
-    ELSE
-    NULL
-  END
-    AS check_source
-  FROM
-    statement_cohort_checks
-  WHERE
-    statement_cohort <> cohort
-    OR (suggested_cohort_from_declaration <> cohort
+      fdmt.declaration_id=si.participant_declaration_id
+    WHERE /*This excludes declarations we already know do not align with the statement cohort but the financial statements have been closed so there is no action to be taken.*/
+      declaration_id NOT IN ('59e5d04c-0741-4e1d-b1c3-8467cafc3ead',
+      'bcf10833-cbce-470b-8afb-6fdea087347b',
+      '0c643297-378e-4fc7-9a82-4bf882369bab',
+      '45d8c5c4-d76e-494a-9570-3c1fa2e26b08',
+      '069fe4b1-3e3f-4b73-a095-20454717f3e1',
+      '3115cd3a-08b1-4afd-a50b-9b595efef6e8',
+      '58f73d2a-c5eb-4034-b131-5e9394705bbe',
+      'dde9d124-cb67-4037-a84a-ef8bc2d4e5a9',
+      '3d74e41b-4647-4f93-b4a1-cbdae4ea03ca',
+      '98f30bf7-c3e6-4794-b3f3-1469e441b6a2',
+      'dff40840-0c86-48d4-bbb2-75cf9c1393dd',
+      '5e9497a8-fbcd-41c9-9c91-902d6f8d1a13',
+      '21e63f72-93ab-449e-ae16-2645150a0c55',
+      '3136548a-cd8b-4240-8577-71ca130897a7',
+      '6b5e82a7-58a5-4904-9375-26eec27ad16f',
+      '8d27404d-e82b-45cc-97e5-77bb83b4be8f',
+      '68c45337-61f1-4f77-aad5-dd8baca851f6',
+      '76ba686a-64b6-45f1-aacc-8f247897b4b7',
+      '041c32ae-04ec-4bac-aad2-5baf204c9703',
+      'b9a9b61f-c9da-407e-a8e1-a190471f7928',
+      '0fe70258-8c92-4fa8-8abd-9bfa47bde443',
+      '7c216ac7-6ff5-4b1b-accb-9d87721f937a',
+      '98b051f7-6b96-4731-9419-830c8bf98efb',
+      '350a8988-e306-490f-824b-87ce2351a789',
+      '2fdd1ea2-d706-421d-b30c-27a1192a0ea9',
+      'db492412-53a6-429c-9480-1629e54aed2f',
+      '0301f4eb-a19b-474b-a1da-e5cc0cfa8352',
+      'e5d83740-9b26-4817-b2ac-257a9f3c3a26',
+      '3695bced-a280-4e3c-b15f-1430c271e7a1',
+      'bbcb45eb-48d2-40d5-a637-fc7b5b27ede3',
+      'c651aeed-3f6b-4aed-b915-d8324a757af2',
+      'a2348288-bfd2-42fb-ba2a-fdfbd6067ee1',
+      'd7ca9990-cb63-4f47-8ae6-606218ffbca5',
+      'df0fa656-0446-4bf1-ba05-90052fa4d146',
+      'b79474b6-7635-46f1-b9e3-5a7f47582930',
+      '98206908-b175-43af-9faa-f025d46e612c',
+      '02fdeecf-b9e6-4de8-914c-7fecd0e47557',
+      '6fc17638-1838-403d-9abb-a95ee6732d5d',
+      '014d61aa-c0b0-486e-ad30-097f241ca0cc',
+      '64f403a4-4c94-4763-8f36-46906ef37000',
+      'bf545cb3-a513-4bd4-8038-fad655959010',
+      '97c28880-6d00-4331-a6e4-622667e1521a',
+      '7ad36b2b-b926-467b-8902-fcee2dd8046d',
+      'bfdcb633-5d62-49ae-8d64-457587d9d279',
+      'c47b1e46-0162-4932-949e-41bb149f2e1b',
+      'b6dc508e-790f-4df3-a92c-c7705cfcc236',
+      '1dbedd79-15b8-4833-9667-26a8d38ae50b')),
+  full_cohort_checker_output AS (
+    SELECT
+      *,
+      CASE /*This CASE statement works out which (if any) of the checks a declaration belongs to, either the financial statement cohort check or comparing declaration date check. Declarations can belong to one or both of the checks, and we're also pulling together all of a participant's declarations, hence the need for the NULL ending.*/
+        WHEN statement_cohort <> cohort AND (suggested_cohort_from_declaration <> cohort 
       AND ((schedule_identifier LIKE 'ecf-standard%'
           AND ((declaration_type = 'started'
               AND (dec_date_short NOT BETWEEN started_dec_start_date
@@ -276,7 +244,86 @@ WITH
             OR (declaration_type = 'retained-4'
               AND dec_date_short < ret4_dec_start_date)
             OR (declaration_type = 'completed'
-              AND dec_date_short < completed_dec_start_date))))))
+              AND dec_date_short < completed_dec_start_date))))) THEN "in both checks"
+        WHEN suggested_cohort_from_declaration <> cohort
+      AND ((schedule_identifier LIKE 'ecf-standard%'
+          AND ((declaration_type = 'started'
+              AND (dec_date_short NOT BETWEEN started_dec_start_date
+                AND started_dec_milestone_date))
+            OR (declaration_type = 'retained-1'
+              AND (dec_date_short NOT BETWEEN ret1_dec_start_date
+                AND ret1_dec_milestone_date))
+            OR (declaration_type = 'retained-2'
+              AND (dec_date_short NOT BETWEEN ret2_dec_start_date
+                AND ret2_dec_milestone_date))
+            OR (declaration_type = 'retained-3'
+              AND (dec_date_short NOT BETWEEN ret3_dec_start_date
+                AND ret3_dec_milestone_date))
+            OR (declaration_type = 'retained-4'
+              AND (dec_date_short NOT BETWEEN ret4_dec_start_date
+                AND ret4_dec_milestone_date))
+            OR (declaration_type = 'completed'
+              AND (dec_date_short NOT BETWEEN completed_dec_start_date
+                AND completed_dec_milestone_date))))
+        OR (schedule_identifier LIKE ANY ('ecf-extended%',
+            'ecf-reduced%',
+            'ecf-replacement%')
+          AND ((declaration_type = 'started'
+              AND dec_date_short < started_dec_start_date)
+            OR (declaration_type = 'retained-1'
+              AND dec_date_short < ret1_dec_start_date)
+            OR (declaration_type = 'retained-2'
+              AND dec_date_short < ret2_dec_start_date)
+            OR (declaration_type = 'retained-3'
+              AND dec_date_short < ret3_dec_start_date)
+            OR (declaration_type = 'retained-4'
+              AND dec_date_short < ret4_dec_start_date)
+            OR (declaration_type = 'completed'
+              AND dec_date_short < completed_dec_start_date)))) THEN "declaration date check"
+        WHEN statement_cohort <> cohort THEN "statement check"
+      ELSE
+      NULL
+    END
+      AS check_source
+    FROM
+      statement_cohort_checks
+    WHERE
+      statement_cohort <> cohort
+      OR (suggested_cohort_from_declaration <> cohort
+        AND ((schedule_identifier LIKE 'ecf-standard%'
+            AND ((declaration_type = 'started'
+                AND (dec_date_short NOT BETWEEN started_dec_start_date
+                  AND started_dec_milestone_date))
+              OR (declaration_type = 'retained-1'
+                AND (dec_date_short NOT BETWEEN ret1_dec_start_date
+                  AND ret1_dec_milestone_date))
+              OR (declaration_type = 'retained-2'
+                AND (dec_date_short NOT BETWEEN ret2_dec_start_date
+                  AND ret2_dec_milestone_date))
+              OR (declaration_type = 'retained-3'
+                AND (dec_date_short NOT BETWEEN ret3_dec_start_date
+                  AND ret3_dec_milestone_date))
+              OR (declaration_type = 'retained-4'
+                AND (dec_date_short NOT BETWEEN ret4_dec_start_date
+                  AND ret4_dec_milestone_date))
+              OR (declaration_type = 'completed'
+                AND (dec_date_short NOT BETWEEN completed_dec_start_date
+                  AND completed_dec_milestone_date))))
+          OR (schedule_identifier LIKE ANY ('ecf-extended%',
+              'ecf-reduced%',
+              'ecf-replacement%')
+            AND ((declaration_type = 'started'
+                AND dec_date_short < started_dec_start_date)
+              OR (declaration_type = 'retained-1'
+                AND dec_date_short < ret1_dec_start_date)
+              OR (declaration_type = 'retained-2'
+                AND dec_date_short < ret2_dec_start_date)
+              OR (declaration_type = 'retained-3'
+                AND dec_date_short < ret3_dec_start_date)
+              OR (declaration_type = 'retained-4'
+                AND dec_date_short < ret4_dec_start_date)
+              OR (declaration_type = 'completed'
+                AND dec_date_short < completed_dec_start_date))))))
 SELECT
   DISTINCT a.*,
   c.suggested_cohort_from_declaration,


### PR DESCRIPTION
I am creating a hard list of declarations to exclude where we know the financial statement cohort is different from the participant's but the statements are closed so no changes can be made. The rest of the changes are making full_cohort_checker_output an inline subquery and some formatting