### PR TITLE
Introduction of LS Mart and amending ecf_inductions

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -69,6 +69,10 @@ dfeAnalyticsDataform({
                 dataType: "string",
                 description: ""
             }, {
+                keyName: "selectable_by_schools",
+                dataType: "boolean",
+                description: ""
+            }, {
                 keyName: "name",
                 dataType: "string",
                 description: ""

--- a/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
@@ -1,8 +1,5 @@
 config {
     type: "table",
-    assertions: {
-        uniqueKey: ["declaration_id"]
-    },
     bigquery: {
         partitionBy: "",
         clusterBy: ["cohort", "participant_course", "cpd_lead_provider_name","declaration_type"]
@@ -98,35 +95,26 @@ WITH
     course_identifier LIKE 'ecf%'),
   ecf_participant_declarations AS (
   SELECT
-    induction_record_id,
-    e_ind.participant_profile_id,
-    school_urn,
-    schedule_identifier,
-    cohort,
-    training_status,
-    induction_status,
-    induction_start_date,
-    induction_completion_date,
-    e_ind.participant_course,
+    e_ind.* EXCEPT(active, rn0),
     e_dec.id as declaration_id,
-    declaration_type,
-    declaration_date,
+    e_dec.declaration_type,
+    e_dec.declaration_date,
     e_dec.state,
-    funded_declaration,
-    cpd_lead_provider_name,
-    e_dec.delivery_partner_name,
-  (ROW_NUMBER() OVER (PARTITION BY e_dec.participant_profile_id, e_dec.course_identifier, e_dec.declaration_type ORDER BY e_dec.state_heirarchy DESC, e_dec.declaration_date desc)) AS rn1 
+    e_dec.funded_declaration,
+    e_dec.cpd_lead_provider_name,
+   (ROW_NUMBER() OVER (PARTITION BY e_ind.participant_profile_id, e_dec.course_identifier, e_dec.declaration_type ORDER BY e_dec.state_heirarchy DESC, e_dec.declaration_date desc)) AS rn1 
   FROM
     ecf_inductions_expanded e_ind
-  Inner join
+  LEFT JOIN
    ecf_declarations_expanded e_dec
   ON
     e_ind.participant_profile_id=e_dec.participant_profile_id
     AND e_ind.participant_course=e_dec.participant_course
   QUALIFY
-  rn1=1)
+  rn1=1
+)
 SELECT
   *
-  EXCEPT(rn1)
+   EXCEPT(rn1)
 FROM
-  ecf_participant_declarations 
+  ecf_participant_declarations

--- a/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
@@ -41,7 +41,8 @@ config {
         core_induction_programme_id: "If a school offers CIP, this will be filled with the ID of their CIP programme.",
         core_induction_materials_provider: "If a school offers CIP, this shows which Lead Provider they are getting their CIP materials from.",
         mentor_completion_date: "The date a mentor completed training.",
-        mentor_completion_reason: "The reason the mentor_completion_date field is filled.Possible values: completed_during_early_roll_out, completed_declaration_received."
+        mentor_completion_reason: "The reason the mentor_completion_date field is filled.Possible values: completed_during_early_roll_out, completed_declaration_received.",
+        cohort_has_changed: "TRUE/FALSE flag streamed from the service as 'cohort_changed_after_payments_frozen' for whether a participant has been moved from the 2021 cohort to the 2024 cohort. This flag is updated by SITs in the service for applicable ECTs."
     }
 }
 
@@ -108,6 +109,7 @@ WITH
     trn AS TRN,
     mentor_completion_date,
     mentor_completion_reason,
+    cohort_changed_after_payments_frozen
     -- trn_validated,
     -- trn_validated_reason,
     -- manual_validation_required,
@@ -182,6 +184,7 @@ FROM
     core_induction_materials_provider,
     mentor_completion_date,
     mentor_completion_reason,
+    cohort_changed_after_payments_frozen AS cohort_has_changed,
     CASE
       WHEN challenged_at IS NOT NULL THEN 'No lead provider'
     ELSE

--- a/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
@@ -33,6 +33,7 @@ config {
         participant_type: "Either ECT or Mentor",
         induction_record_created_at: "When this induction record was generated.",
         partnership_id: "ID for the Lead Provider-School partnership for a given cohort.",
+        partnership_relationship: "TRUE/FALSE for the partnership_id taken from partnerships_latest_cpd. The relationship is 'live' when the value returns FALSE.",
         TRN: "This comes from a participant's teacher profile.",
         cohort: "The cohort/academic year corresponding to when the participant started their course. Possible fields: 2021 onwards.",
         school_id: "ID of the participant's school.",
@@ -42,7 +43,7 @@ config {
         core_induction_materials_provider: "If a school offers CIP, this shows which Lead Provider they are getting their CIP materials from.",
         mentor_completion_date: "The date a mentor completed training.",
         mentor_completion_reason: "The reason the mentor_completion_date field is filled.Possible values: completed_during_early_roll_out, completed_declaration_received.",
-        cohort_has_changed: "TRUE/FALSE flag streamed from the service as 'cohort_changed_after_payments_frozen' for whether a participant has been moved from the 2021 cohort to the 2024 cohort. This flag is updated by SITs in the service for applicable ECTs."
+        cohort_rolled_over_21_24: "TRUE/FALSE flag streamed from the service as 'cohort_changed_after_payments_frozen' for whether a participant has been moved from the 2021 cohort to the 2024 cohort. This flag is updated by SITs in the service for applicable ECTs."
     }
 }
 
@@ -67,8 +68,9 @@ WITH
     ${ref("induction_records_latest_cpd")}),
   ecf_induction_programmes AS (
   SELECT
-    DISTINCT id AS induction_programme_id,
+    DISTINCT induction_prog.id AS induction_programme_id,
     partnership_id,
+    prt.relationship AS partnership_relationship,
     school_cohort_id,
     training_programme AS induction_programme_type,
     induction_prog.core_induction_programme_id,
@@ -78,7 +80,11 @@ WITH
   LEFT JOIN
     ${ref('core_induction_materials_providers')} AS cip_materials_providers
   ON
-    induction_prog.core_induction_programme_id=cip_materials_providers.core_induction_programme_id),
+    induction_prog.core_induction_programme_id=cip_materials_providers.core_induction_programme_id
+  LEFT JOIN
+    ${ref('partnerships_latest_cpd')} AS prt
+  ON
+    prt.id = induction_prog.partnership_id),
   cohort_records AS(
   SELECT
     school_cohort.id AS school_cohort_id,
@@ -175,6 +181,7 @@ FROM
     participant_type,
     induction_record_created_at,
     induction_programme_details.partnership_id,
+    induction_programme_details.partnership_relationship,
     TRN,
     induction_programme_details.cohort,
     induction_programme_details.school_id,
@@ -184,7 +191,7 @@ FROM
     core_induction_materials_provider,
     mentor_completion_date,
     mentor_completion_reason,
-    cohort_changed_after_payments_frozen AS cohort_has_changed,
+    cohort_changed_after_payments_frozen AS cohort_rolled_over_21_24,
     CASE
       WHEN challenged_at IS NOT NULL THEN 'No lead provider'
     ELSE

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -4,7 +4,7 @@ config {
         uniqueKey: ["declaration_id"]
     },
     bigquery: {
-        partitionBy: "current_cohort",
+        partitionBy: "",
         clusterBy: ["participant_role", "participant_profile_id"]
     },
     description: "This mart combines elements of the ECF Golden Thread and relevant declarations (submitted, eligible, payable, paid) for both ECTs and Mentors to assess if the currently assigned cohort is in line with the suggested cohort based on the induction start date for ECTs and the earliest declaration date for Mentors. \n \

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -2,9 +2,9 @@ config {
     type: "table",
     bigquery: {
         partitionBy: "",
-        clusterBy: ["current_cohort", "participant_role", "participant_profile_id"]
+        clusterBy: ["current_cohort", "participant_role"]
     },
-    description: "This mart combines elements of the ECF Golden Thread and relevant declarations (submitted, eligible, payable, paid) for both ECTs and Mentors to assess if the currently assigned cohort is in line with the suggested cohort based on the induction start date for ECTs and the earliest declaration date for Mentors. \n \
+    description: "This mart contains relevant declarations (submitted, eligible, payable, paid) for both ECTs and Mentors to assess if the currently assigned cohort is in line with the suggested cohort based on the induction start date for ECTs and the earliest declaration date for Mentors. \n \
     Objective: \n \
         To gather all ECTs & Mentors inducted within 2021-2023 cohorts for evaluation as to whether they are allocated to correct the cohort based on criteria below. \n \
     Instructions: \n \
@@ -14,7 +14,7 @@ config {
             AND \n \
             participant_role = 'ECT' \n \
             AND \n \
-            declaration_id IS NOT NULL \n \
+            declaration_state IN ('submitted', 'eligible', 'payable', 'paid') \n \
             AND \n \
             -- Check if the lead provider is NIOT and there is a Live Partnership in place. \n \
             niot_partnership_chk = 0 \n \
@@ -26,7 +26,7 @@ config {
             AND \n \
             participant_role = 'Mentor' \n \
             AND \n \
-            declaration_id IS NOT NULL \n \
+            declaration_state IN ('submitted', 'eligible', 'payable', 'paid') \n \
             AND \n \
             -- Check if the lead provider is NIOT and there is a Live Partnership in place. \n \
             niot_partnership_chk = 0 \n \
@@ -38,7 +38,7 @@ config {
             AND \n \
             participant_role = 'ECT' \n \
             AND \n \
-            declaration_id IS NULL \n \
+            declaration_state NOT IN ('submitted', 'eligible', 'payable', 'paid') \n \
             AND \n \
             has_relevant_declarations = FALSE \n \
             AND \n \
@@ -88,7 +88,7 @@ config {
         AND
         participant_role = 'ECT'
         AND 
-        declaration_id IS NOT NULL
+        declaration_state IN ('submitted', 'eligible', 'payable', 'paid')
         AND
         niot_partnership_chk = 0
         AND
@@ -100,7 +100,7 @@ config {
         AND
         participant_role = 'Mentor'
         AND 
-        declaration_id IS NOT NULL
+        declaration_state IN ('submitted', 'eligible', 'payable', 'paid')
         AND
         niot_partnership_chk = 0
         AND
@@ -112,7 +112,7 @@ config {
         AND
         participant_role = 'ECT'
         AND 
-        declaration_id IS NULL
+        declaration_state NOT IN ('submitted', 'eligible', 'payable', 'paid')
         AND
         has_relevant_declarations = FALSE
         AND
@@ -142,11 +142,11 @@ WITH declarations AS(
     ,dec.partnership_relationship
     ,dec.lead_provider_name AS induction_lead_provider_name
     ,dec.cohort_rolled_over_21_24
-    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),dec.declaration_id, NULL) AS declaration_id
-    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),DATE(declaration_date), NULL) AS declaration_date
-    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),dec.declaration_type, NULL) AS declaration_type
-    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'), state, NULL) AS declaration_state
-    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),dec.cpd_lead_provider_name, NULL) AS lead_provider_name
+    ,dec.declaration_id
+    ,DATE(declaration_date) AS declaration_date
+    ,dec.declaration_type
+    ,state AS declaration_state
+    ,dec.cpd_lead_provider_name AS lead_provider_name
     ,MIN(CASE WHEN state IN ('paid', 'payable', 'eligible') THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
     ,CASE
       WHEN SUM(relevant_dec_state) OVER (PARTITION BY participant_profile_id) > 0 THEN TRUE 
@@ -157,7 +157,7 @@ WITH declarations AS(
       *,
       CASE WHEN state IN ('eligible','payable','paid','submitted') THEN 1 ELSE 0 END AS relevant_dec_state
     FROM
-      ${ref('ecf_declarations')}
+      `dataform__TP_Dev.ecf_declarations`
     ) dec
 ),
 
@@ -205,14 +205,10 @@ combined_data AS (
       ELSE 0
      END AS unique_participant_counter
     -- Generate row number to allow removal of duplicated NULL declarations created by replacing values when not a relevant state (s/e/p/p)
-    ,ROW_NUMBER() OVER(PARTITION BY participant_profile_id, declaration_id) AS rn0
   FROM 
     declarations
   WHERE
     participant_role IS NOT NULL
-  QUALIFY(
-    rn0 = 1
-  )
   ORDER BY
     user_id ASC, participant_profile_id ASC, participant_role ASC, declaration_date ASC
 ),
@@ -235,7 +231,7 @@ output_data AS (
 
 -- Generate output
 SELECT
-  * EXCEPT(rn0)
+  *
   ,IF(induction_start_date IS NOT NULL, TRUE, FALSE) AS has_induction_start_date
 FROM 
   output_data

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -46,7 +46,7 @@ config {
             start_date_suggestion_match = 0 \n \
     Dependencies: \n \
         dataform.ecf_golden_thread \n \
-        dataform.ls_declarations_provider_names",
+        dataform.ecf_declarations",
     columns: {
         user_id: "This comes from the teacher profile associated with the participant profile. User ID also exists independently in other tables.",
         participant_profile_id: "The ID from a participant's profile in the CPD service.",
@@ -65,6 +65,11 @@ config {
         partnership_relationship: "TRUE/FALSE for the partnership_id taken from partnerships_latest_cpd. The relationship is 'live' when the value returns FALSE.",
         earliest_declaration_date: "The first declaration date for the participant_profile_id where the declaration is funded (eligible, payable or paid).",
         unique_participant_counter: "1 or 0 if the row is the first instance of the participant_profile_id. Used in reporting as a means of gaining unique count of participants.",
+        niot_partnership_chk: "1 or 0 if the declaration relates to a participant with an active school-lead provider relationship and the lead provider is NIOT",
+        start_date_suggestion_match: "1 or 0 if the suggested cohort based on induction start date matches with the current cohort in the servce.",
+        earliest_dec_suggestion_match: "1 or 0 if the suggest cohort based on the earliest funded declaration for the participant matches the current cohort in the service.",
+        has_relevant_declarations: "TRUE/FALSE if the participant has any s/e/p/p declarations present.",
+        cohort_rolled_over_21_24: "TRUE/FALSE flag from the service as to whether the participant's cohort has been changed from 2021 to 2024.",
         has_induction_start_date: "TRUE/FALSE if the induction_start_date field is not null."
     }
 }
@@ -108,82 +113,74 @@ config {
         AND 
         declaration_id IS NULL
         AND
+        has_relevant_declarations = FALSE
+        AND
         niot_partnership_chk = 0
         AND
         start_date_suggestion_match = 0
 
   Dependencies:
-    dataform.ecf_golden_thread
-    dataform.ls_declarations_provider_names
-    dataform.partnerships_latest_cpd
-
-  Version History:
-    1.0 2024-06-05 Tony Page
-      Initial Build
+    dataform.ecf_declarations
 */
 
--- Gather ECF Golden Thread
-WITH golden_thread AS( 
+-- Gather ECF Declarations
+WITH declarations AS( 
   SELECT
      -- Manually assign the user_id for specific participant profile where the profile no longer exists in latest_cpd data and has no superceeded record to call upon.
      CASE 
-      WHEN egt.participant_profile_id = '8cd0928c-ecad-482f-95cd-6a0ff3e840ad' THEN '79dee4de-a6dd-407c-ab1c-690fcb6d0056'
-      ELSE egt.user_id
+      WHEN dec.participant_profile_id = '8cd0928c-ecad-482f-95cd-6a0ff3e840ad' THEN '79dee4de-a6dd-407c-ab1c-690fcb6d0056'
+      ELSE dec.user_id
      END AS user_id
-    ,egt.participant_profile_id
-    ,egt.participant_course AS participant_role
-    ,egt.schedule_identifier
-    ,egt.induction_start_date AS induction_start_date
-    ,egt.cohort
-    ,egt.eligible_for_funding
-    ,egt.partnership_id
-    ,egt.partnership_relationship
-    ,egt.lead_provider_name AS induction_lead_provider_name
-  FROM 
-    ${ref('ecf_golden_thread')} AS egt
-),
-
--- Collect all s/e/p/p declarations relating to ECF in the appropriate states.
-declarations AS (
-  SELECT
-     declaration_id
-    ,DATE(declaration_date) AS declaration_date
-    ,declaration_type
-    ,state AS declaration_state
-    ,participant_profile_id
-    ,cpd_lead_provider_name AS lead_provider_name
-    -- Calculate earliest declaration date for the participant for funded declarations only.
+    ,dec.participant_profile_id
+    ,dec.participant_course AS participant_role
+    ,dec.schedule_identifier
+    ,dec.induction_start_date AS induction_start_date
+    ,dec.cohort
+    ,dec.eligible_for_funding
+    ,dec.partnership_id
+    ,dec.partnership_relationship
+    ,dec.lead_provider_name AS induction_lead_provider_name
+    ,dec.cohort_rolled_over_21_24
+    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),dec.declaration_id, NULL) AS declaration_id
+    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),DATE(declaration_date), NULL) AS declaration_date
+    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),dec.declaration_type, NULL) AS declaration_type
+    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'), state, NULL) AS declaration_state
+    ,IF(dec.state IN ('submitted', 'paid', 'payable', 'eligible'),dec.cpd_lead_provider_name, NULL) AS lead_provider_name
     ,MIN(CASE WHEN state IN ('paid', 'payable', 'eligible') THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
-  FROM
-    ${ref('ecf_declarations')}
-  WHERE
-    state IN (
-       'paid'
-      ,'payable'
-      ,'eligible'
-      ,'submitted'
-    )
+    ,CASE
+      WHEN SUM(relevant_dec_state) OVER (PARTITION BY participant_profile_id) > 0 THEN TRUE 
+      ELSE FALSE 
+     END AS has_relevant_declarations
+  FROM 
+    (SELECT
+      *,
+      CASE WHEN state IN ('eligible','payable','paid','submitted') THEN 1 ELSE 0 END AS relevant_dec_state
+    FROM
+      ${ref('ecf_declarations')}
+    ) dec
 ),
 
--- Join declarations onto deduped induction records & add on the grouping of suggested cohorts by induction start date and earliest declaration..
+-- Add on the grouping of suggested cohorts by induction start date and earliest declaration, Partnership-NIOT check flag, unique participant flag and row number for duplication removal of nulled declarations. 
 combined_data AS (
   SELECT 
-     pro.user_id
-    ,pro.participant_profile_id
-    ,pro.participant_role
-    ,pro.schedule_identifier AS current_schedule
-    ,dec.declaration_id
-    ,dec.declaration_date
-    ,dec.lead_provider_name
-    ,IF(pro.induction_lead_provider_name = 'No lead provider', NULL, pro.induction_lead_provider_name) AS induction_lead_provider_name
-    ,dec.declaration_type
-    ,dec.declaration_state
-    ,pro.cohort AS current_cohort
-    ,pro.induction_start_date
-    ,pro.eligible_for_funding
-    ,pro.partnership_id
-    ,pro.partnership_relationship
-    ,dec.earliest_declaration_date AS earliest_declaration_date
+     user_id
+    ,participant_profile_id
+    ,participant_role
+    ,schedule_identifier AS current_schedule
+    ,declaration_id
+    ,declaration_date
+    ,lead_provider_name
+    ,IF(induction_lead_provider_name = 'No lead provider', NULL, induction_lead_provider_name) AS induction_lead_provider_name
+    ,declaration_type
+    ,declaration_state
+    ,cohort AS current_cohort
+    ,induction_start_date
+    ,eligible_for_funding
+    ,partnership_id
+    ,partnership_relationship
+    ,earliest_declaration_date AS earliest_declaration_date
+    ,has_relevant_declarations
+    ,cohort_rolled_over_21_24
     ,CASE
       WHEN induction_start_date < '2021-09-01' THEN '2023'
       WHEN induction_start_date BETWEEN '2021-09-01' AND '2022-05-31' THEN '2021'
@@ -199,23 +196,24 @@ combined_data AS (
       WHEN earliest_declaration_date BETWEEN '2023-09-01' AND '2024-05-31' THEN '2023'
      END AS earliest_dec_suggested_true_cohort
     ,CASE
-      WHEN pro.partnership_id IS NOT NULL AND pro.partnership_relationship = FALSE AND dec.lead_provider_name = 'National Institute of Teaching' THEN 1
+      WHEN partnership_id IS NOT NULL AND partnership_relationship = FALSE AND lead_provider_name = 'National Institute of Teaching' THEN 1
       ELSE 0
      END AS niot_partnership_chk
     ,CASE
-      WHEN ROW_NUMBER() OVER(PARTITION BY pro.participant_profile_id ORDER BY dec.declaration_date ASC) = 1 THEN 1
+      WHEN ROW_NUMBER() OVER(PARTITION BY participant_profile_id ORDER BY declaration_date ASC) = 1 THEN 1
       ELSE 0
      END AS unique_participant_counter
+    -- Generate row number to allow removal of duplicated NULL declarations created by replacing values when not a relevant state (s/e/p/p)
+    ,ROW_NUMBER() OVER(PARTITION BY participant_profile_id, declaration_id) AS rn0
   FROM 
-    golden_thread pro
-  LEFT JOIN 
-    declarations dec 
-  ON
-    pro.participant_profile_id = dec.participant_profile_id
+    declarations
   WHERE
-    pro.participant_role IS NOT NULL
+    participant_role IS NOT NULL
+  QUALIFY(
+    rn0 = 1
+  )
   ORDER BY
-    pro.user_id ASC, pro.participant_profile_id ASC, pro.participant_role ASC, dec.declaration_date ASC
+    user_id ASC, participant_profile_id ASC, participant_role ASC, declaration_date ASC
 ),
 
 -- Build preliminary output data which includes the binary result for cohort matching each of the suggested values.
@@ -235,8 +233,8 @@ output_data AS (
 )
 
 -- Generate output
-SELECT 
-  *
+SELECT
+  * EXCEPT(rn0)
   ,IF(induction_start_date IS NOT NULL, TRUE, FALSE) AS has_induction_start_date
 FROM 
   output_data

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -155,7 +155,7 @@ declarations AS (
     -- Calculate earliest declaration date for the participant for funded declarations only.
     ,MIN(CASE WHEN state IN ('paid', 'payable', 'eligible') THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
   FROM
-    ${ref('ecf_inductions')}
+    ${ref('ecf_declarations')}
   WHERE
     state IN (
        'paid'

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -66,7 +66,7 @@ config {
         partnership_relationship: "TRUE/FALSE for the partnership_id taken from partnerships_latest_cpd. The relationship is 'live' when the value returns FALSE.",
         earliest_declaration_date: "The first declaration date for the participant_profile_id where the declaration is funded (eligible, payable or paid).",
         unique_participant_counter: "1 or 0 if the row is the first instance of the participant_profile_id. Used in reporting as a means of gaining unique count of participants.",
-        niot_partnership_chk: "1 or 0 if the declaration relates to a participant with an active school-lead provider relationship and the lead provider is NIOT. When this equals 1 the declaration/participant is not to be assessed for whether it is in the correct cohort.",
+        niot_partnership_chk: "1 or 0 if the declaration relates to a participant with an active school-lead provider relationship and the lead provider is NIOT. When this equals 1 the declaration/participant is not to be assessed for whether it is in the correct cohort. NIOT are only able to train participants in the 2023 cohorts onwards, so contract managers have occasionally greenlit them to train an ECT whose induction began before 1/9/2023 under the later cohort.",
         start_date_suggestion_match: "1 or 0 if the suggested cohort based on induction start date matches with the current cohort in the servce.",
         earliest_dec_suggestion_match: "1 or 0 if the suggest cohort based on the earliest funded declaration for the participant matches the current cohort in the service.",
         has_relevant_declarations: "TRUE/FALSE if the participant has any s/e/p/p declarations present.",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -152,6 +152,7 @@ WITH declarations AS(
       WHEN SUM(relevant_dec_state) OVER (PARTITION BY participant_profile_id) > 0 THEN TRUE 
       ELSE FALSE 
      END AS has_relevant_declarations
+    ,IF(induction_start_date IS NOT NULL, TRUE, FALSE) AS has_induction_start_date
   FROM 
     (SELECT
       *,
@@ -206,6 +207,5 @@ SELECT
     WHEN INSTR(earliest_dec_suggested_true_cohort, CAST(current_cohort AS STRING)) > 0 THEN 1
     ELSE 0
     END AS earliest_dec_suggestion_match
-  ,IF(induction_start_date IS NOT NULL, TRUE, FALSE) AS has_induction_start_date
 FROM 
   combined_data

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -136,11 +136,11 @@ WITH declarations AS(
     ,dec.participant_course AS participant_role
     ,dec.schedule_identifier
     ,dec.induction_start_date AS induction_start_date
-    ,dec.cohort
+    ,dec.cohort AS current_cohort
     ,dec.eligible_for_funding
     ,dec.partnership_id
     ,dec.partnership_relationship
-    ,dec.lead_provider_name AS induction_lead_provider_name
+    ,IF(lead_provider_name = 'No lead provider', NULL, lead_provider_name) AS induction_lead_provider_name
     ,dec.cohort_rolled_over_21_24
     ,dec.declaration_id
     ,DATE(declaration_date) AS declaration_date
@@ -164,24 +164,7 @@ WITH declarations AS(
 -- Add on the grouping of suggested cohorts by induction start date and earliest declaration, Partnership-NIOT check flag, unique participant flag and row number for duplication removal of nulled declarations. 
 combined_data AS (
   SELECT 
-     user_id
-    ,participant_profile_id
-    ,participant_role
-    ,schedule_identifier AS current_schedule
-    ,declaration_id
-    ,declaration_date
-    ,lead_provider_name
-    ,IF(induction_lead_provider_name = 'No lead provider', NULL, induction_lead_provider_name) AS induction_lead_provider_name
-    ,declaration_type
-    ,declaration_state
-    ,cohort AS current_cohort
-    ,induction_start_date
-    ,eligible_for_funding
-    ,partnership_id
-    ,partnership_relationship
-    ,earliest_declaration_date AS earliest_declaration_date
-    ,has_relevant_declarations
-    ,cohort_rolled_over_21_24
+     *
     ,CASE
       WHEN induction_start_date < '2021-09-01' THEN '2023'
       WHEN induction_start_date BETWEEN '2021-09-01' AND '2022-05-31' THEN '2021'
@@ -204,34 +187,25 @@ combined_data AS (
       WHEN ROW_NUMBER() OVER(PARTITION BY participant_profile_id ORDER BY declaration_date ASC) = 1 THEN 1
       ELSE 0
      END AS unique_participant_counter
-    -- Generate row number to allow removal of duplicated NULL declarations created by replacing values when not a relevant state (s/e/p/p)
   FROM 
     declarations
   WHERE
     participant_role IS NOT NULL
   ORDER BY
     user_id ASC, participant_profile_id ASC, participant_role ASC, declaration_date ASC
-),
-
--- Build preliminary output data which includes the binary result for cohort matching each of the suggested values.
-output_data AS (
-  SELECT 
-    *
-    ,CASE
-      WHEN INSTR(start_date_suggested_true_cohort, CAST(current_cohort AS STRING)) > 0 THEN 1
-      ELSE 0
-     END AS start_date_suggestion_match
-    ,CASE
-      WHEN INSTR(earliest_dec_suggested_true_cohort, CAST(current_cohort AS STRING)) > 0 THEN 1
-      ELSE 0
-     END AS earliest_dec_suggestion_match
-  FROM
-   combined_data
 )
 
 -- Generate output
 SELECT
-  *
+   *
+  ,CASE
+    WHEN INSTR(start_date_suggested_true_cohort, CAST(current_cohort AS STRING)) > 0 THEN 1
+    ELSE 0
+    END AS start_date_suggestion_match
+  ,CASE
+    WHEN INSTR(earliest_dec_suggested_true_cohort, CAST(current_cohort AS STRING)) > 0 THEN 1
+    ELSE 0
+    END AS earliest_dec_suggestion_match
   ,IF(induction_start_date IS NOT NULL, TRUE, FALSE) AS has_induction_start_date
 FROM 
-  output_data
+  combined_data

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -1,8 +1,5 @@
 config {
     type: "table",
-    assertions: {
-        uniqueKey: ["declaration_id"]
-    },
     bigquery: {
         partitionBy: "",
         clusterBy: ["participant_role", "participant_profile_id"]

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -66,7 +66,7 @@ config {
         partnership_relationship: "TRUE/FALSE for the partnership_id taken from partnerships_latest_cpd. The relationship is 'live' when the value returns FALSE.",
         earliest_declaration_date: "The first declaration date for the participant_profile_id where the declaration is funded (eligible, payable or paid).",
         unique_participant_counter: "1 or 0 if the row is the first instance of the participant_profile_id. Used in reporting as a means of gaining unique count of participants.",
-        niot_partnership_chk: "1 or 0 if the declaration relates to a participant with an active school-lead provider relationship and the lead provider is NIOT",
+        niot_partnership_chk: "1 or 0 if the declaration relates to a participant with an active school-lead provider relationship and the lead provider is NIOT. When this equals 1 the declaration/participant is not to be assessed for whether it is in the correct cohort.",
         start_date_suggestion_match: "1 or 0 if the suggested cohort based on induction start date matches with the current cohort in the servce.",
         earliest_dec_suggestion_match: "1 or 0 if the suggest cohort based on the earliest funded declaration for the participant matches the current cohort in the service.",
         has_relevant_declarations: "TRUE/FALSE if the participant has any s/e/p/p declarations present.",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -145,9 +145,9 @@ WITH golden_thread AS(
     ,prt.relationship AS partnership_relationship
     ,egt.lead_provider_name AS induction_lead_provider_name
   FROM 
-    `dataform.ecf_golden_thread` egt
+    ${ref('ecf_golden_thread')} AS egt
   LEFT JOIN
-    `dataform.partnerships_latest_cpd` prt
+    ${ref('partnerships_latest_cpd')} AS prt
   ON
     prt.id = egt.partnership_id
 ),
@@ -165,7 +165,7 @@ declarations AS (
     -- Calculate earliest declaration date for the participant for funded declarations only.
     ,MIN(CASE WHEN state IN ('paid', 'payable', 'eligible') THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
   FROM
-    `dataform.ls_declarations_provider_names`
+    ${ref('ls_declarations_provider_names')}
   WHERE
     programme = 'ECF'
     AND

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -147,7 +147,7 @@ WITH declarations AS(
     ,dec.declaration_type
     ,state AS declaration_state
     ,dec.cpd_lead_provider_name AS lead_provider_name
-    ,MIN(CASE WHEN state IN ('paid', 'payable', 'eligible') THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
+    ,MIN(CASE WHEN funded_declaration = TRUE THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
     ,CASE
       WHEN SUM(relevant_dec_state) OVER (PARTITION BY participant_profile_id) > 0 THEN TRUE 
       ELSE FALSE 
@@ -156,7 +156,7 @@ WITH declarations AS(
   FROM 
     (SELECT
       *,
-      CASE WHEN state IN ('eligible','payable','paid','submitted') THEN 1 ELSE 0 END AS relevant_dec_state
+      CASE WHEN funded_declaration = TRUE OR state = 'submitted' THEN 1 ELSE 0 END AS relevant_dec_state
     FROM
       `dataform__TP_Dev.ecf_declarations`
     ) dec

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -40,12 +40,13 @@ config {
             AND \n \
             declaration_id IS NULL \n \
             AND \n \
+            has_relevant_declarations = FALSE \n \
+            AND \n \
             -- Check if the lead provider is NIOT and there is a Live Partnership in place. \n \
             niot_partnership_chk = 0 \n \
             AND \n \
             start_date_suggestion_match = 0 \n \
     Dependencies: \n \
-        dataform.ecf_golden_thread \n \
         dataform.ecf_declarations",
     columns: {
         user_id: "This comes from the teacher profile associated with the participant profile. User ID also exists independently in other tables.",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -2,7 +2,7 @@ config {
     type: "table",
     bigquery: {
         partitionBy: "",
-        clusterBy: ["participant_role", "participant_profile_id"]
+        clusterBy: ["current_cohort", "participant_role", "participant_profile_id"]
     },
     description: "This mart combines elements of the ECF Golden Thread and relevant declarations (submitted, eligible, payable, paid) for both ECTs and Mentors to assess if the currently assigned cohort is in line with the suggested cohort based on the induction start date for ECTs and the earliest declaration date for Mentors. \n \
     Objective: \n \
@@ -16,6 +16,7 @@ config {
             AND \n \
             declaration_id IS NOT NULL \n \
             AND \n \
+            -- Check if the lead provider is NIOT and there is a Live Partnership in place. \n \
             niot_partnership_chk = 0 \n \
             AND \n \
             start_date_suggestion_match = 0 \n \
@@ -27,6 +28,7 @@ config {
             AND \n \
             declaration_id IS NOT NULL \n \
             AND \n \
+            -- Check if the lead provider is NIOT and there is a Live Partnership in place. \n \
             niot_partnership_chk = 0 \n \
             AND \n \
             earliest_dec_suggestion_match = 0 \n \
@@ -38,13 +40,13 @@ config {
             AND \n \
             declaration_id IS NULL \n \
             AND \n \
+            -- Check if the lead provider is NIOT and there is a Live Partnership in place. \n \
             niot_partnership_chk = 0 \n \
             AND \n \
             start_date_suggestion_match = 0 \n \
     Dependencies: \n \
         dataform.ecf_golden_thread \n \
-        dataform.ls_declarations_provider_names \n \
-        dataform.partnerships_latest_cpd",
+        dataform.ls_declarations_provider_names",
     columns: {
         user_id: "This comes from the teacher profile associated with the participant profile. User ID also exists independently in other tables.",
         participant_profile_id: "The ID from a participant's profile in the CPD service.",
@@ -58,7 +60,7 @@ config {
         declaration_state: "The state of the declaration which for this mart can only be submitted, eligible, payable, or paid. (s/e/p/p)",
         current_cohort: "The cohort/academic year corresponding to when the participant started their course as per the service.",
         induction_start_date: "The date when the ECT or Mentor started their induction taken from their Participant Profile.",
-        eligible_for_funding: "TRUE/FALSE flag as per ecf_golden_thread for funding eligibility.",
+        eligible_for_funding: "TRUE/FALSE flag for funding eligibility.",
         partnership_id: "ID for the Lead Provider-School partnership for a given cohort.",
         partnership_relationship: "TRUE/FALSE for the partnership_id taken from partnerships_latest_cpd. The relationship is 'live' when the value returns FALSE.",
         earliest_declaration_date: "The first declaration date for the participant_profile_id where the declaration is funded (eligible, payable or paid).",
@@ -129,43 +131,32 @@ WITH golden_thread AS(
       ELSE egt.user_id
      END AS user_id
     ,egt.participant_profile_id
-    ,CASE
-      WHEN egt.participant_type LIKE '%ECT' THEN 'ECT'
-      WHEN egt.participant_type LIKE '%Mentor' THEN 'Mentor'
-      ELSE NULL
-     END AS participant_role
+    ,egt.participant_course AS participant_role
     ,egt.schedule_identifier
     ,egt.induction_start_date AS induction_start_date
     ,egt.cohort
     ,egt.eligible_for_funding
     ,egt.partnership_id
-    ,prt.relationship AS partnership_relationship
+    ,egt.partnership_relationship
     ,egt.lead_provider_name AS induction_lead_provider_name
   FROM 
     ${ref('ecf_golden_thread')} AS egt
-  LEFT JOIN
-    ${ref('partnerships_latest_cpd')} AS prt
-  ON
-    prt.id = egt.partnership_id
 ),
 
 -- Collect all s/e/p/p declarations relating to ECF in the appropriate states.
 declarations AS (
   SELECT
-     id AS declaration_id
+     declaration_id
     ,DATE(declaration_date) AS declaration_date
     ,declaration_type
     ,state AS declaration_state
     ,participant_profile_id
-    ,cpd_lead_provider_id AS lead_provider_id
-    ,cpd_lp_name AS lead_provider_name
+    ,cpd_lead_provider_name AS lead_provider_name
     -- Calculate earliest declaration date for the participant for funded declarations only.
     ,MIN(CASE WHEN state IN ('paid', 'payable', 'eligible') THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
   FROM
-    ${ref('ls_declarations_provider_names')}
+    ${ref('ecf_inductions')}
   WHERE
-    programme = 'ECF'
-    AND
     state IN (
        'paid'
       ,'payable'
@@ -211,7 +202,10 @@ combined_data AS (
       WHEN pro.partnership_id IS NOT NULL AND pro.partnership_relationship = FALSE AND dec.lead_provider_name = 'National Institute of Teaching' THEN 1
       ELSE 0
      END AS niot_partnership_chk
-    ,ROW_NUMBER() OVER(PARTITION BY pro.participant_profile_id ORDER BY pro.participant_profile_id ASC) AS participant_precedence
+    ,CASE
+      WHEN ROW_NUMBER() OVER(PARTITION BY pro.participant_profile_id ORDER BY dec.declaration_date ASC) = 1 THEN 1
+      ELSE 0
+     END AS unique_participant_counter
   FROM 
     golden_thread pro
   LEFT JOIN 
@@ -229,27 +223,20 @@ output_data AS (
   SELECT 
     *
     ,CASE
-      WHEN start_date_suggested_true_cohort = '2023' AND current_cohort = 2023 THEN 1
-      WHEN start_date_suggested_true_cohort = '2022' AND current_cohort = 2022 THEN 1
-      WHEN start_date_suggested_true_cohort = '2021' AND current_cohort = 2021 THEN 1
-      WHEN start_date_suggested_true_cohort = '2022,2023' AND current_cohort IN (2022, 2023) THEN 1
-      WHEN start_date_suggested_true_cohort = '2021,2022' AND current_cohort IN (2021, 2022) THEN 1
+      WHEN INSTR(start_date_suggested_true_cohort, CAST(current_cohort AS STRING)) > 0 THEN 1
       ELSE 0
      END AS start_date_suggestion_match
     ,CASE
-      WHEN earliest_dec_suggested_true_cohort = '2023' AND current_cohort = 2023 THEN 1
-      WHEN earliest_dec_suggested_true_cohort = '2021,2022,2023' AND current_cohort IN (2021,2022,2023) THEN 1
-      WHEN earliest_dec_suggested_true_cohort = '2021,2022' AND current_cohort IN (2021,2022) THEN 1
+      WHEN INSTR(earliest_dec_suggested_true_cohort, CAST(current_cohort AS STRING)) > 0 THEN 1
       ELSE 0
      END AS earliest_dec_suggestion_match
-    ,IF(participant_precedence = 1, 1, 0) AS unique_participant_counter
   FROM
    combined_data
 )
 
 -- Generate output
 SELECT 
-  * EXCEPT(participant_precedence)
+  *
   ,IF(induction_start_date IS NOT NULL, TRUE, FALSE) AS has_induction_start_date
 FROM 
   output_data

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -1,0 +1,258 @@
+config {
+    type: "table",
+    assertions: {
+        uniqueKey: ["declaration_id"]
+    },
+    bigquery: {
+        partitionBy: "cohort",
+        clusterBy: ["participant_role", "participant_profile_id"]
+    },
+    description: "This mart combines elements of the ECF Golden Thread and relevant declarations (submitted, eligible, payable, paid) for both ECTs and Mentors to assess if the currently assigned cohort is in line with the suggested cohort based on the induction start date for ECTs and the earliest declaration date for Mentors. \n \
+    Objective: \n \
+        To gather all ECTs & Mentors inducted within 2021-2023 cohorts for evaluation as to whether they are allocated to correct the cohort based on criteria below. \n \
+    Instructions: \n \
+        For ECTs in the 'wrong' cohort with declarations: \n \
+          WHERE \n \
+            eligible_for_funding = TRUE \n \
+            AND \n \
+            participant_role = 'ECT' \n \
+            AND \n \
+            declaration_id IS NOT NULL \n \
+            AND \n \
+            niot_partnership_chk = 0 \n \
+            AND \n \
+            start_date_suggestion_match = 0 \n \
+        For Mentors in the 'wrong' cohort with declarations: \n \
+          WHERE \n \
+            eligible_for_funding = TRUE \n \
+            AND \n \
+            participant_role = 'Mentor' \n \
+            AND \n \
+            declaration_id IS NOT NULL \n \
+            AND \n \
+            niot_partnership_chk = 0 \n \
+            AND \n \
+            earliest_dec_suggestion_match = 0 \n \
+        For ECTs in the 'wrong' cohort without declarations: \n \
+           WHERE \n \
+            eligible_for_funding = TRUE \n \
+            AND \n \
+            participant_role = 'ECT' \n \
+            AND \n \
+            declaration_id IS NULL \n \
+            AND \n \
+            niot_partnership_chk = 0 \n \
+            AND \n \
+            start_date_suggestion_match = 0 \n \
+    Dependencies: \n \
+        dataform.ecf_golden_thread \n \
+        dataform.ls_declarations_provider_names \n \
+        dataform.partnerships_latest_cpd",
+    columns: {
+        user_id: "This comes from the teacher profile associated with the participant profile. User ID also exists independently in other tables.",
+        participant_profile_id: "The ID from a participant's profile in the CPD service.",
+        participant_role: "The role of the participant which is either ECT or Mentor as per the participant type.",
+        current_schedule: "The schedule as per the participant profile.",
+        declaration_id: "The unique identifier for the declaration.",
+        declaration_date: "The date of when evidence was submitted against the declaration.",
+        lead_provider_name: "The name of the Lead Provider that submitted the declaration.",
+        induction_lead_provider_name: "The name of the Lead Provider associated with the induction record. Used for ECTs & Mentors with zero s/e/p/p declarations.",
+        declaration_type: "The type of declaration which can be started, retained-#, extended-# or completed. #'s range from 1 to 4.",
+        declaration_state: "The state of the declaration which for this mart can only be submitted, eligible, payable, or paid. (s/e/p/p)",
+        current_cohort: "The cohort/academic year corresponding to when the participant started their course as per the service.",
+        induction_start_date: "The date when the ECT or Mentor started their induction taken from their Participant Profile.",
+        eligible_for_funding: "TRUE/FALSE flag as per ecf_golden_thread for funding eligibility.",
+        partnership_id: "ID for the Lead Provider-School partnership for a given cohort.",
+        partnership_relationship: "TRUE/FALSE for the partnership_id taken from partnerships_latest_cpd. The relationship is 'live' when the value returns FALSE.",
+        earliest_declaration_date: "The first declaration date for the participant_profile_id where the declaration is funded (eligible, payable or paid).",
+        unique_participant_counter: "1 or 0 if the row is the first instance of the participant_profile_id. Used in reporting as a means of gaining unique count of participants.",
+        has_induction_start_date: "TRUE/FALSE if the induction_start_date field is not null."
+    }
+}
+
+/*** ECF Cohort Corrections Looker Studio Data Mart ***/
+
+/*
+  Objective:
+    To gather all ECTs & Mentors inducted within 2021-2023 cohorts for evaluation as to whether they are allocated to correct the cohort based on criteria below.
+
+  Instructions:
+    For ECTs in the "wrong" cohort with declarations:
+      WHERE
+        eligible_for_funding = TRUE
+        AND
+        participant_role = 'ECT'
+        AND 
+        declaration_id IS NOT NULL
+        AND
+        niot_partnership_chk = 0
+        AND
+        start_date_suggestion_match = 0
+      
+    For Mentors in the "wrong" cohort with declarations:
+      WHERE
+        eligible_for_funding = TRUE
+        AND
+        participant_role = 'Mentor'
+        AND 
+        declaration_id IS NOT NULL
+        AND
+        niot_partnership_chk = 0
+        AND
+        earliest_dec_suggestion_match = 0
+
+    For ECTs in the "wrong" cohort without declarations:
+      WHERE
+        eligible_for_funding = TRUE
+        AND
+        participant_role = 'ECT'
+        AND 
+        declaration_id IS NULL
+        AND
+        niot_partnership_chk = 0
+        AND
+        start_date_suggestion_match = 0
+
+  Dependencies:
+    dataform.ecf_golden_thread
+    dataform.ls_declarations_provider_names
+    dataform.partnerships_latest_cpd
+
+  Version History:
+    1.0 2024-06-05 Tony Page
+      Initial Build
+*/
+
+-- Gather ECF Golden Thread
+WITH golden_thread AS( 
+  SELECT
+     -- Manually assign the user_id for specific participant profile where the profile no longer exists in latest_cpd data and has no superceeded record to call upon.
+     CASE 
+      WHEN egt.participant_profile_id = '8cd0928c-ecad-482f-95cd-6a0ff3e840ad' THEN '79dee4de-a6dd-407c-ab1c-690fcb6d0056'
+      ELSE egt.user_id
+     END AS user_id
+    ,egt.participant_profile_id
+    ,CASE
+      WHEN egt.participant_type LIKE '%ECT' THEN 'ECT'
+      WHEN egt.participant_type LIKE '%Mentor' THEN 'Mentor'
+      ELSE NULL
+     END AS participant_role
+    ,egt.schedule_identifier
+    ,egt.induction_start_date AS induction_start_date
+    ,egt.cohort
+    ,egt.eligible_for_funding
+    ,egt.partnership_id
+    ,prt.relationship AS partnership_relationship
+    ,egt.lead_provider_name AS induction_lead_provider_name
+  FROM 
+    `dataform.ecf_golden_thread` egt
+  LEFT JOIN
+    `dataform.partnerships_latest_cpd` prt
+  ON
+    prt.id = egt.partnership_id
+),
+
+-- Collect all s/e/p/p declarations relating to ECF in the appropriate states.
+declarations AS (
+  SELECT
+     id AS declaration_id
+    ,DATE(declaration_date) AS declaration_date
+    ,declaration_type
+    ,state AS declaration_state
+    ,participant_profile_id
+    ,cpd_lead_provider_id AS lead_provider_id
+    ,cpd_lp_name AS lead_provider_name
+    -- Calculate earliest declaration date for the participant for funded declarations only.
+    ,MIN(CASE WHEN state IN ('paid', 'payable', 'eligible') THEN DATE(declaration_date) ELSE DATE(2050,12,31) END) OVER (PARTITION BY participant_profile_id) AS earliest_declaration_date
+  FROM
+    `dataform.ls_declarations_provider_names`
+  WHERE
+    programme = 'ECF'
+    AND
+    state IN (
+       'paid'
+      ,'payable'
+      ,'eligible'
+      ,'submitted'
+    )
+),
+
+-- Join declarations onto deduped induction records & add on the grouping of suggested cohorts by induction start date and earliest declaration..
+combined_data AS (
+  SELECT 
+     pro.user_id
+    ,pro.participant_profile_id
+    ,pro.participant_role
+    ,pro.schedule_identifier AS current_schedule
+    ,dec.declaration_id
+    ,dec.declaration_date
+    ,dec.lead_provider_name
+    ,IF(pro.induction_lead_provider_name = 'No lead provider', NULL, pro.induction_lead_provider_name) AS induction_lead_provider_name
+    ,dec.declaration_type
+    ,dec.declaration_state
+    ,pro.cohort AS current_cohort
+    ,pro.induction_start_date
+    ,pro.eligible_for_funding
+    ,pro.partnership_id
+    ,pro.partnership_relationship
+    ,dec.earliest_declaration_date AS earliest_declaration_date
+    ,CASE
+      WHEN induction_start_date < '2021-09-01' THEN '2023'
+      WHEN induction_start_date BETWEEN '2021-09-01' AND '2022-05-31' THEN '2021'
+      WHEN induction_start_date BETWEEN '2022-06-01' AND '2022-08-31' THEN '2021,2022'
+      WHEN induction_start_date BETWEEN '2022-09-01' AND '2023-05-31' THEN '2022'
+      WHEN induction_start_date BETWEEN '2023-06-01' AND '2023-08-31' THEN '2022,2023'
+      WHEN induction_start_date BETWEEN '2023-09-01' AND '2024-05-31' THEN '2023'
+      ELSE NULL
+    END AS start_date_suggested_true_cohort
+    ,CASE
+      WHEN earliest_declaration_date BETWEEN '2021-09-01' AND '2023-05-31' THEN '2021,2022'
+      WHEN earliest_declaration_date BETWEEN '2023-06-01' AND '2023-08-31' THEN '2021,2022,2023'
+      WHEN earliest_declaration_date BETWEEN '2023-09-01' AND '2024-05-31' THEN '2023'
+     END AS earliest_dec_suggested_true_cohort
+    ,CASE
+      WHEN pro.partnership_id IS NOT NULL AND pro.partnership_relationship = FALSE AND dec.lead_provider_name = 'National Institute of Teaching' THEN 1
+      ELSE 0
+     END AS niot_partnership_chk
+    ,ROW_NUMBER() OVER(PARTITION BY pro.participant_profile_id ORDER BY pro.participant_profile_id ASC) AS participant_precedence
+  FROM 
+    golden_thread pro
+  LEFT JOIN 
+    declarations dec 
+  ON
+    pro.participant_profile_id = dec.participant_profile_id
+  WHERE
+    pro.participant_role IS NOT NULL
+  ORDER BY
+    pro.user_id ASC, pro.participant_profile_id ASC, pro.participant_role ASC, dec.declaration_date ASC
+),
+
+-- Build preliminary output data which includes the binary result for cohort matching each of the suggested values.
+output_data AS (
+  SELECT 
+    *
+    ,CASE
+      WHEN start_date_suggested_true_cohort = '2023' AND current_cohort = 2023 THEN 1
+      WHEN start_date_suggested_true_cohort = '2022' AND current_cohort = 2022 THEN 1
+      WHEN start_date_suggested_true_cohort = '2021' AND current_cohort = 2021 THEN 1
+      WHEN start_date_suggested_true_cohort = '2022,2023' AND current_cohort IN (2022, 2023) THEN 1
+      WHEN start_date_suggested_true_cohort = '2021,2022' AND current_cohort IN (2021, 2022) THEN 1
+      ELSE 0
+     END AS start_date_suggestion_match
+    ,CASE
+      WHEN earliest_dec_suggested_true_cohort = '2023' AND current_cohort = 2023 THEN 1
+      WHEN earliest_dec_suggested_true_cohort = '2021,2022,2023' AND current_cohort IN (2021,2022,2023) THEN 1
+      WHEN earliest_dec_suggested_true_cohort = '2021,2022' AND current_cohort IN (2021,2022) THEN 1
+      ELSE 0
+     END AS earliest_dec_suggestion_match
+    ,IF(participant_precedence = 1, 1, 0) AS unique_participant_counter
+  FROM
+   combined_data
+)
+
+-- Generate output
+SELECT 
+  * EXCEPT(participant_precedence)
+  ,IF(induction_start_date IS NOT NULL, TRUE, FALSE) AS has_induction_start_date
+FROM 
+  output_data

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_correct_cohort_checker.sqlx
@@ -4,7 +4,7 @@ config {
         uniqueKey: ["declaration_id"]
     },
     bigquery: {
-        partitionBy: "cohort",
+        partitionBy: "current_cohort",
         clusterBy: ["participant_role", "participant_profile_id"]
     },
     description: "This mart combines elements of the ECF Golden Thread and relevant declarations (submitted, eligible, payable, paid) for both ECTs and Mentors to assess if the currently assigned cohort is in line with the suggested cohort based on the induction start date for ECTs and the earliest declaration date for Mentors. \n \

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@dataform/core": "2.9.0",
-                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.0.tar.gz"
+                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz"
             }
         },
         "node_modules/@dataform/core": {
@@ -15,8 +15,8 @@
             "integrity": "sha512-S0aJMpof0uxL7Sodi7CH3ewlN83NFm0kRDvWoBfc0prw/a5wVIAY1LZWeg/6icqKPUw5b5xWn2ub82YrD8zVTg=="
         },
         "node_modules/dfe-analytics-dataform": {
-            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.0.tar.gz",
-            "integrity": "sha512-3s3M1Bg/ie98YxkvI/grS4z88KsSZSFEy1YegY3QQ7AoExOtJZU8nbrPhmnhbO/8Vcy01h4a7V5iokZyyolE0A==",
+            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz",
+            "integrity": "sha512-G/veBdIgKWlrKYfpT3bX22m+ItxWkesUouggav+yJ+ErZw1wH2skzPcvczz2ff+gV09Rnuf49bkym/p0VJ40SA==",
             "dependencies": {
                 "@dataform/core": "3.0.0-beta.5"
             }
@@ -34,8 +34,8 @@
             "integrity": "sha512-S0aJMpof0uxL7Sodi7CH3ewlN83NFm0kRDvWoBfc0prw/a5wVIAY1LZWeg/6icqKPUw5b5xWn2ub82YrD8zVTg=="
         },
         "dfe-analytics-dataform": {
-            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.0.tar.gz",
-            "integrity": "sha512-3s3M1Bg/ie98YxkvI/grS4z88KsSZSFEy1YegY3QQ7AoExOtJZU8nbrPhmnhbO/8Vcy01h4a7V5iokZyyolE0A==",
+            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz",
+            "integrity": "sha512-G/veBdIgKWlrKYfpT3bX22m+ItxWkesUouggav+yJ+ErZw1wH2skzPcvczz2ff+gV09Rnuf49bkym/p0VJ40SA==",
             "requires": {
                 "@dataform/core": "3.0.0-beta.5"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "@dataform/core": "2.9.0",
-        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.0.tar.gz"
+        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz"
     }
 }


### PR DESCRIPTION
ecf_inductions has been amended to include the new field cohort_changed_after_payments_frozen to be used later this month for change tracking of ECT's between cohorts '21 & '24.

Introduction of ls_ecf_correct_cohort_checker to support Looker dashboard of similar name and replace query currently being used.