### PR TITLE
Introduction of 2 LS Marts for ECF Mentor Backfill Grant Funding.

### DIFF
--- a/definitions/declarations/gias_establishments.sqlx
+++ b/definitions/declarations/gias_establishments.sqlx
@@ -1,0 +1,5 @@
+config {
+    type: "declaration",
+    schema: "gias",
+    name: "establishments"
+}

--- a/definitions/declarations/static_tables/ecf_mentor_backfill_grant_funding_review_cases.sqlx
+++ b/definitions/declarations/static_tables/ecf_mentor_backfill_grant_funding_review_cases.sqlx
@@ -1,0 +1,5 @@
+config {
+    type: "declaration",
+    schema: "static_tables",
+    name: "ecf_mentor_backfill_grant_funding_review_cases"
+}

--- a/definitions/declarations/static_tables/ecf_mentor_backfill_previously_paid.sqlx
+++ b/definitions/declarations/static_tables/ecf_mentor_backfill_previously_paid.sqlx
@@ -1,0 +1,5 @@
+config {
+    type: "declaration",
+    schema: "static_tables",
+    name: "ecf_mentors_previously_paid"
+}

--- a/definitions/declarations/static_tables/la_teacher_pay_band_grouping.sqlx
+++ b/definitions/declarations/static_tables/la_teacher_pay_band_grouping.sqlx
@@ -1,0 +1,5 @@
+config {
+    type: "declaration",
+    schema: "static_tables",
+    name: "la_teacher_pay_band_grouping"
+}

--- a/definitions/declarations/static_tables/teacher_pay_band_36_hour_cost.sqlx
+++ b/definitions/declarations/static_tables/teacher_pay_band_36_hour_cost.sqlx
@@ -1,0 +1,5 @@
+config {
+    type: "declaration",
+    schema: "static_tables",
+    name: "teacher_pay_band_36_hour_cost"
+}

--- a/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
@@ -102,6 +102,7 @@ WITH
     e_dec.state,
     e_dec.funded_declaration,
     e_dec.cpd_lead_provider_name,
+    e_dec.delivery_partner_name,
    (ROW_NUMBER() OVER (PARTITION BY e_ind.participant_profile_id, e_dec.course_identifier, e_dec.declaration_type ORDER BY e_dec.state_heirarchy DESC, e_dec.declaration_date desc)) AS rn1 
   FROM
     ecf_inductions_expanded e_ind

--- a/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
@@ -7,7 +7,8 @@ config {
     description: "This mart joins the latest induction record for a given ECF participant (found in the ecf_inductions_dedupe mart) with the relevant ecf declarations for that participant resulting in one row per declaration per participant. In order to determine the preferred declaration for each declaration type (if multiple records exist for the same declaration type) we've determined a preferred state_heirarchy:paid>payable>eligible>submitted>clawed_back>awaiting_clawback>voided ",
     columns: {
         induction_record_id: "ID of individual induction record",
-        participant_course: "This is a shortened version of participant_type"
+        participant_course: "This is a shortened version of participant_type",
+        cpd_delivery_partner_name: "The name of the Delivery Partner taken from the declaration record rather than the induction record."
     }
 }
 
@@ -102,7 +103,7 @@ WITH
     e_dec.state,
     e_dec.funded_declaration,
     e_dec.cpd_lead_provider_name,
-    e_dec.delivery_partner_name,
+    e_dec.delivery_partner_name AS cpd_delivery_partner_name,
    (ROW_NUMBER() OVER (PARTITION BY e_ind.participant_profile_id, e_dec.course_identifier, e_dec.declaration_type ORDER BY e_dec.state_heirarchy DESC, e_dec.declaration_date desc)) AS rn1 
   FROM
     ecf_inductions_expanded e_ind

--- a/definitions/marts/bigquery_marts/npq/npq_enrolments.sqlx
+++ b/definitions/marts/bigquery_marts/npq/npq_enrolments.sqlx
@@ -83,7 +83,8 @@ config {
         works_in_school: "Indicates whether the participant works in a school. ",
         funded_place: "This indicates if the accepted NPQ application is being funded by the DfE as one of the capped funded places. Being eligible for funding does not guarantee the application will be funded.",
         senco_in_role: "Pulled from separate NPQ pipline as not fed into ECF App data that dataform runs on. Answer selected for question 'Are you a SENCO?' during the application stage. Possible results are; yes, no but I plan to be, no and I do not plan to be.",
-        senco_start_date: "Pulled from separate NPQ pipline as not fed into ECF App data that dataform runs on. Provided at time of application and only answered if 'yes' is selected for Are you a SENCO. Format is MM/YYYY stored as a string."
+        senco_start_date: "Pulled from separate NPQ pipline as not fed into ECF App data that dataform runs on. Provided at time of application and only answered if 'yes' is selected for Are you a SENCO. Format is MM/YYYY stored as a string.",
+        valid_application: "TRUE/FALSE currently checking for 2 known NPQ SENCO issues. If the application has NULL for senco_in_role or it is 'yes' but the senco_start_date is NULL then this flag is set to FALSE."
     }
 }
 
@@ -561,6 +562,11 @@ SELECT
    gt.* EXCEPT(rn10)
   ,app.senco_in_role
   ,app.senco_start_date
+  ,CASE
+    WHEN gt.course_name LIKE '%SENCO%' AND senco_in_role IS NULL THEN FALSE -- SENCO application must have this question answered during application process or else it is a "Ghost" application.
+    WHEN gt.course_name LIKE '%SENCO%' AND senco_in_role = 'yes' AND senco_start_date IS NULL THEN FALSE -- If an applicant answers yes to Are you a SENCO when applying for the NPQ SENCO course, they must provide a start date.
+    ELSE TRUE
+   END AS valid_application
 FROM
   npq_gold_thread AS gt
 -- Join on NPQ Application data for 2 SENCO related fields not currently (as of 05/07/2024) being streamed into the ECF app nor Dataform pipeline.

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_gf_review_cases.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_gf_review_cases.sqlx
@@ -1,0 +1,110 @@
+config {
+    type: "table",    
+    bigquery: {
+      clusterBy: ["used_school_urn"]
+    },
+    description: "This mart produces an output at declaration/mentor level for mentors who Grant Funding have said they should have had their declarations clawed back in the last academic year. These individuals should not be in receipt of Grant Funding this year unless deemed necessary by the GF Team. The output of this table enables the GF Team to perform the necessary reviews.",
+    columns: {
+      user_id: "This comes from the teacher profile associated with the participant profile.",
+      review_file_school_urn: "The School URN provided for the Mentor in the list of review cases provided by Grant Funding. BQ Source = static_tables.ecf_mentor_backfill_grant_funding_review_cases",
+      declaration_id: "The unique identifier of the declaration.",
+      participant_profile_id: "The id of the participant associated with the declaration.",
+      declaration_type: "The type of declaration which can be started, retained-1/2/3/4, extended-1/2/3 or completed.",
+      declaration_state: "The state of the declaration which for this mart can only be funded (eligible/payable/paid)",
+      declaration_type_hierarchy: "A number from 1 to 9 based on started to completed declaration types to enable sorting in the correct sequence regardless of declaration date.",
+      declaration_created_at: "The date the declaration record was created in the service.",
+      declaration_date: "The date the declaration was evidenced.",
+      lead_provider_name: "The name of the lead provider as per the declaration record.",
+      delivery_partner_name: "The name of the delivery partner as per the declaration record or where null from the induction record.",
+      latest_induction_record_id: "The id of the latest induction record associated with the participant profile id.",
+      induction_record_school_urn: "The school urn associated with the latest induction record.",
+      declaration_date_school_urn: "The school urn associated with the induction record valid on the declaration date where a declaration is present.",
+      used_school_urn: "The school urn used for aggregation. This is determined by the first non-null value from declaration_date_school_urn, induction_record_school_urn",
+      previously_paid: "TRUE/FALSE if the user_id appears in the static table of previously paid mentors. If a mentor was paid for in Instalment 1 then any started, retained-1/2 declarations present are marked as TRUE. If a mentor was paid for in Instalment 2 then any retained-3/4, completed declarations are marked as TRUE.",
+      declaration_match: "TRUE/FALSE if the declaration ID found matches to the declaration ID provided by Grant Funding in the file static_tables.ecf_mentor_backfill_grant_funding_review_cases"
+   }
+}
+
+WITH review_cases AS (
+  SELECT
+     rev.user_id
+    ,rev.school_urn AS review_file_school_urn
+    ,dec.declaration_id
+    ,dec.participant_profile_id
+    ,dec.declaration_type
+    ,dec.state AS declaration_state
+    ,CASE
+      WHEN dec.declaration_type = 'started' THEN 1
+      WHEN dec.declaration_type = 'retained-1' THEN 2
+      WHEN dec.declaration_type = 'retained-2' THEN 3
+      WHEN dec.declaration_type = 'retained-3' THEN 4
+      WHEN dec.declaration_type = 'retained-4' THEN 5
+      WHEN dec.declaration_type = 'extended-1' THEN 6
+      WHEN dec.declaration_type = 'extended-2' THEN 7
+      WHEN dec.declaration_type = 'extended-3' THEN 8
+      WHEN dec.declaration_type = 'completed' THEN 9
+      ELSE NULL
+     END AS declaration_type_hierarchy
+    ,DATE(dp.created_at) AS declaration_created_at
+    ,DATE(dec.declaration_date) AS declaration_date
+    ,dec.cpd_lead_provider_name AS lead_provider_name
+    ,COALESCE(dec.cpd_delivery_partner_name, dec.delivery_partner_name) AS delivery_partner_name
+    ,dec.induction_record_id AS latest_induction_record_id
+    ,dec.school_urn AS induction_record_school_urn -- School URN of latest induction record.
+    ,ind.school_urn AS declaration_date_school_urn
+    ,COALESCE(ind.school_urn, dec.school_urn, rev.school_urn) AS used_school_urn
+    ,CASE
+      WHEN pp.user_id IS NOT NULL THEN TRUE 
+      ELSE FALSE
+     END AS previously_paid
+    ,CASE
+      WHEN rev.declaration_id = dec.declaration_id THEN TRUE
+      ELSE FALSE
+     END AS declaration_match
+    ,CASE
+      WHEN dec.declaration_id IS NULL THEN 1
+      ELSE ROW_NUMBER() OVER(PARTITION BY dec.declaration_id ORDER BY ind.start_date DESC)
+     END AS rn0
+  FROM
+    ${ref('ecf_mentor_backfill_grant_funding_review_cases')} AS rev
+  LEFT JOIN
+    ${ref('ecf_declarations')} AS dec  
+  ON
+    rev.user_id = dec.user_id
+    AND
+    dec.funded_declaration = TRUE
+    AND
+    dec.declaration_type IN ('retained-3', 'retained-4', 'completed')
+    AND
+    dec.participant_course = 'Mentor'
+
+  LEFT JOIN
+    ${ref('ecf_mentors_previously_paid')} AS pp
+  ON
+    pp.user_id = rev.user_id
+    AND
+    pp.payment_period = 'Instalment 2 - 2023'
+  
+  LEFT JOIN
+    ${ref('ecf_inductions')} AS ind
+  ON
+    ind.participant_profile_id = dec.participant_profile_id
+    AND
+    DATE(dec.declaration_date) BETWEEN DATE(ind.start_date) AND DATE(IFNULL(ind.end_date, '2050-12-31'))
+
+  LEFT JOIN
+    ${ref('ls_declarations_provider_names')} dp
+  ON
+    dp.id = dec.declaration_id
+
+  QUALIFY(
+    rn0 = 1
+  )
+)
+
+SELECT 
+  * EXCEPT(rn0)
+FROM 
+  review_cases
+ORDER BY
+  user_id ASC, declaration_type_hierarchy ASC

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_gf_review_cases.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_gf_review_cases.sqlx
@@ -106,5 +106,3 @@ SELECT
   * EXCEPT(rn0)
 FROM 
   review_cases
-ORDER BY
-  user_id ASC, declaration_type_hierarchy ASC

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
@@ -1,0 +1,206 @@
+config {
+    type: "table",
+    assertions: {
+        uniqueKey: ["declaration_id"]
+    },
+    bigquery: {
+        partitionBy: "declaration_date",
+        clusterBy: ["used_school_urn"]
+    },
+    description: "",
+    columns: {
+        declaration_id: "",
+        participant_profile_id: "",
+        user_id: "",
+        TRN: "",
+        declaration_type: "",
+        declaration_state: "",
+        declaration_type_hierarchy: "",
+        declaration_date: "",
+        lead_provider_name: "",
+        delivery_partner_name: "",
+        latest_induction_record_id: "",
+        induction_record_school_urn: "",
+        declaration_date_school_urn: "",
+        induction_record_id_on_declaration_date: "",
+        used_school_urn: "",
+        funded_hours: "",
+        unique_school_urn_count: "",
+        declaration_sequence: "",
+        funded_hours_cost: "",
+        previously_paid: "",
+        local_authority: "",
+        la_code: "",
+        teacher_pay_band: "",
+        gias_school_name: "",
+        gias_establishment_type: "",
+        gias_phase_of_education: "",
+        gias_establishment_status: "",
+        school_mentor_count: "",
+        school_ect_count: "",
+        school_mentor_backfill_funded_hours: "",
+        fractional_ect_count: ""
+   }
+}
+
+WITH declarations AS (
+  SELECT
+     dec.declaration_id
+    ,dec.participant_profile_id
+    ,dec.user_id
+    ,dec.TRN
+    ,dec.declaration_type
+    ,dec.state AS declaration_state
+    ,CASE
+      WHEN dec.declaration_type = 'started' THEN 1
+      WHEN dec.declaration_type = 'retained-1' THEN 2
+      WHEN dec.declaration_type = 'retained-2' THEN 3
+      WHEN dec.declaration_type = 'retained-3' THEN 4
+      WHEN dec.declaration_type = 'retained-4' THEN 5
+      WHEN dec.declaration_type = 'extended-1' THEN 6
+      WHEN dec.declaration_type = 'extended-2' THEN 7
+      WHEN dec.declaration_type = 'extended-3' THEN 8
+      WHEN dec.declaration_type = 'completed' THEN 9
+      ELSE NULL
+     END AS declaration_type_hierarchy
+    ,DATE(dec.declaration_date) AS declaration_date
+    ,dec.cpd_lead_provider_name AS lead_provider_name
+    ,COALESCE(dec.cpd_delivery_partner_name, dec.delivery_partner_name) AS delivery_partner_name
+    ,dec.induction_record_id AS latest_induction_record_id
+    ,dec.school_urn AS induction_record_school_urn -- School URN of latest induction record.
+    ,COALESCE(ind.school_urn, ind2.school_urn) AS declaration_date_school_urn -- School URN on the induction record valid on the declaration date.
+    ,COALESCE(ind.induction_record_id, ind2.induction_record_id) AS induction_record_id_on_declaration_date
+    ,COALESCE(ind.school_urn, dec.school_urn) AS used_school_urn
+    -- For each started, retained-1/2/3/4 or completed declaration 6 hours of funding is allocated.
+    ,CASE
+      WHEN dec.declaration_type IN ('started', 'retained-1', 'retained-2', 'retained-3', 'retained-4', 'completed') THEN 6
+      ELSE 0
+     END AS funded_hours
+    ,CASE
+      WHEN ROW_NUMBER() OVER(PARTITION BY COALESCE(ind.school_urn, ind2.school_urn, dec.school_urn)) = 1 THEN 1
+      ELSE 0
+     END AS unique_school_urn_count
+    ,CASE
+      WHEN (ROW_NUMBER() OVER(PARTITION BY dec.declaration_id ORDER BY COALESCE(ind.start_date, ind2.start_date) DESC)) = 1 THEN 1
+      ELSE 0
+     END AS rn0
+  FROM
+    ${ref('ecf_declarations')} AS dec
+  LEFT JOIN
+    ${ref('ecf_inductions')} AS ind
+  ON
+    ind.participant_profile_id = dec.participant_profile_id
+    AND
+    DATE(dec.declaration_date) BETWEEN DATE(ind.start_date) AND DATE(IFNULL(ind.end_date, '2050-12-31'))
+
+
+  LEFT JOIN
+    ${ref('ecf_inductions')} ind2
+  ON
+    ind2.participant_profile_id = dec.participant_profile_id
+    AND
+    DATE(dec.declaration_date) < IFNULL(DATE(ind2.end_date), '2050-12-31')
+    AND
+    ind.induction_record_id IS NULL
+
+  WHERE
+    funded_declaration = TRUE
+    AND
+    participant_course = 'Mentor'
+    AND
+    dec.declaration_date >= '2023-09-01'
+  QUALIFY (
+    rn0 = 1
+  )
+),
+
+ects AS (
+  SELECT
+     sch.urn
+    ,COUNT(1) AS school_ect_count
+  FROM
+    ${ref('participant_profiles_latest_cpd')} pp
+  LEFT JOIN
+    ${ref('school_cohorts_latest_cpd')} scho
+  ON
+    scho.id = pp.school_cohort_id
+  LEFT JOIN
+    ${ref('schools_latest_cpd')} sch
+  ON
+    sch.id = scho.school_id
+  WHERE
+    type LIKE '%ECT'
+    AND
+    induction_completion_date IS NULL OR induction_completion_date > '2023-08-31'
+  GROUP BY
+    sch.urn
+  ORDER BY
+    school_ect_count DESC
+),
+
+declarations_extended AS (
+  SELECT
+     dec.*
+    ,ROW_NUMBER() OVER(PARTITION BY dec.participant_profile_id ORDER BY declaration_type_hierarchy ASC) AS declaration_sequence
+    ,ROUND((cost.cost_for_36_hours / 36) * dec.funded_hours, 2) AS funded_hours_cost
+    ,CASE
+      WHEN pp1.user_id IS NOT NULL THEN TRUE
+      WHEN pp2.user_id IS NOT NULL THEN TRUE
+      ELSE FALSE
+     END AS previously_paid
+    ,gias.LA_Name AS local_authority
+    ,gias.LA_code AS la_code
+    ,band.teacher_pay_band
+    ,gias.EstablishmentName AS gias_school_name
+    ,gias.TypeOfEstablishment_name AS gias_establishment_type
+    ,gias.PhaseOfEducation_name AS gias_phase_of_education
+    ,gias.EstablishmentStatus_name AS gias_establishment_status
+    ,COUNT(DISTINCT dec.participant_profile_id) OVER(PARTITION BY dec.used_school_urn) AS school_mentor_count
+    ,ects.school_ect_count
+  FROM
+    declarations dec
+  LEFT JOIN
+    ects
+  ON
+    ects.urn = dec.used_school_urn
+  LEFT JOIN
+    ${ref('establishments')} AS gias
+  ON
+    CAST(gias.urn AS INT) = dec.used_school_urn
+  LEFT JOIN
+    ${ref('la_teacher_pay_band_grouping')} AS band
+  ON
+    band.LA_code = CAST(gias.LA_code AS INT)
+  LEFT JOIN
+    ${ref('ecf_mentors_previously_paid')} AS pp1
+  ON
+    pp1.user_id = dec.user_id
+    AND
+    dec.declaration_type IN ('started', 'retained-1', 'retained-2')
+    AND
+    pp1.payment_period LIKE 'Instalment 1%'
+  LEFT JOIN
+    ${ref('ecf_mentors_previously_paid')} AS pp2
+  ON
+    pp2.user_id = dec.user_id
+    AND
+    dec.declaration_type IN ('retained-3', 'retained-4', 'completed')
+    AND
+    pp2.payment_period LIKE 'Instalment 2%'
+  LEFT JOIN
+    ${ref('teacher_pay_band_36_hour_cost')} AS cost
+  ON
+    cost.teacher_pay_band = band.teacher_pay_band
+)
+
+SELECT
+   * EXCEPT(rn0)
+  -- Funded hours per school for mentors not previously paid to enable aggregation at school level for relevant cases only.
+  ,SUM(CASE WHEN previously_paid = FALSE THEN funded_hours ELSE 0 END) OVER(PARTITION BY used_school_urn) AS school_mentor_backfill_funded_hours
+  -- School ECT count evenly distributed across rows for mentors who were not previously paid to enable aggregation at School level in the dashboard output.
+  ,CASE
+    WHEN previously_paid = FALSE THEN school_ect_count / (SUM(CASE WHEN previously_paid = FALSE THEN 1 ELSE 0 END) OVER(PARTITION BY used_school_urn))
+    ELSE 0
+   END AS fractional_ect_count
+FROM
+  declarations_extended

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
@@ -7,39 +7,39 @@ config {
         partitionBy: "declaration_date",
         clusterBy: ["used_school_urn"]
     },
-    description: "",
+    description: "This mart produces an output at declaration level for mentors who require backfill grant funding payments. This mart can also be used to aggregate the number of mentors and hours associated at the School URN level. This is designed to assist the Grant Funding team in determining final payments required to be made to establishments that made provision in order for this mentors to mentor ECTs. The financial values produced via this mart are not the exact amount due as the value has been divided and re-multiplied accordingly resulting in a decimal difference. The GF team are aware of this and know to use the financial value as a guide rather than an absolute amount.",
     columns: {
-        declaration_id: "",
-        participant_profile_id: "",
-        user_id: "",
-        TRN: "",
-        declaration_type: "",
-        declaration_state: "",
-        declaration_type_hierarchy: "",
-        declaration_date: "",
-        lead_provider_name: "",
-        delivery_partner_name: "",
-        latest_induction_record_id: "",
-        induction_record_school_urn: "",
-        declaration_date_school_urn: "",
-        induction_record_id_on_declaration_date: "",
-        used_school_urn: "",
-        funded_hours: "",
-        unique_school_urn_count: "",
-        declaration_sequence: "",
-        funded_hours_cost: "",
-        previously_paid: "",
-        local_authority: "",
-        la_code: "",
-        teacher_pay_band: "",
-        gias_school_name: "",
-        gias_establishment_type: "",
-        gias_phase_of_education: "",
-        gias_establishment_status: "",
-        school_mentor_count: "",
-        school_ect_count: "",
-        school_mentor_backfill_funded_hours: "",
-        fractional_ect_count: ""
+        declaration_id: "The unique identifier of the declaration.",
+        participant_profile_id: "The id of the participant associated with the declaration.",
+        user_id: "This comes from the teacher profile associated with the participant profile.",
+        TRN: "This comes from a participant's teacher profile.",
+        declaration_type: "The type of declaration which can be started, retained-1/2/3/4, extended-1/2/3 or completed.",
+        declaration_state: "The state of the declaration which for this mart can only be funded (eligible/payable/paid)",
+        declaration_type_hierarchy: "A number from 1 to 9 based on started to completed declaration types to enable sorting in the correct sequence regardless of declaration date.",
+        declaration_date: "The date the declaration was evidenced.",
+        lead_provider_name: "The name of the lead provider as per the declaration record.",
+        delivery_partner_name: "The name of the delivery partner as per the declaration record or where null from the induction record.",
+        latest_induction_record_id: "The id of the latest induction record associated with the participant profile id.",
+        induction_record_school_urn: "The school urn associated with the latest induction record.",
+        declaration_date_school_urn: "The school urn associated with the induction record valid on the declaration date.",
+        induction_record_id_on_declaration_date: "The induction record id for the record valud on the declaration date.",
+        used_school_urn: "The school urn used for aggregation. This is determined by the first non-null value from declaration_date_school_urn, induction_record_school_urn",
+        funded_hours: "If the declaration type is not extended-1/2/3 it is allocated 6 hours as per the specification of the Grant Funding allocation.",
+        unique_school_urn_count: "1 or 0 to be summed in order to count the number of unique school urns present in the used_school_urn_field.",
+        declaration_sequence: "Per participant profile id a row number is applied in order to sequence the declarations associated with them. In the payment period a maximum of 3 declarations should be present however, some have 4 or more which may need to be excluded by the Grant Funding team in their final calcualtions.",
+        funded_hours_cost: "The cost associated with the number of hours attributed to the declaration. This cost is weighted by teacher_pay_band and a division of the 36 hour amount provided multiplied by the funded_hours marked against the declaration.",
+        previously_paid: "TRUE/FALSE if the user_id appears in the static table of previously paid mentors. If a mentor was paid for in Instalment 1 then any started, retained-1/2 declarations present are marked as TRUE. If a mentor was paid for in Instalment 2 then any retained-3/4, completed declarations are marked as TRUE.",
+        local_authority: "The local authority name associated with the used_school_urn currently in GIAS.",
+        la_code: "The local authority code associated with the used_school_urn.",
+        teacher_pay_band: "The band associated to the local_authority as provided by the Grant Funding Team.",
+        gias_school_name: "The school name currently in GIAS for the used_school_urn.",
+        gias_establishment_type: "The establishment type currently in GIAS for the used_school_urn.",
+        gias_phase_of_education: "The phase of education currently in GIAS for the used_school_urn.",
+        gias_establishment_status: "The establishment status currently in GIAS for the used_school_urn.",
+        school_mentor_count: "The count of all unique participant profile ids (Mentors) present in this mart where not previously paid aggregated at the used_school_urn.",
+        school_ect_count: "The count of all unique participant profile ids (ECTs) present in participant_profiles_latest_cpd where induction_completed_date is either NULL or after 31/08/2023, aggregated at the used_school_urn.",
+        school_mentor_backfill_funded_hours: "Sum of funded_hours as per this mart aggregated at the used_school_urn where previously_paid is FALSE.",
+        fractional_ect_count: "The ect_count for the used_school_urn split evenly across all rows of the mart where previously_paid is FALSE. This enables accurate summing to occur in the Looker Dashboard."
    }
 }
 
@@ -65,12 +65,12 @@ WITH declarations AS (
      END AS declaration_type_hierarchy
     ,DATE(dec.declaration_date) AS declaration_date
     ,dec.cpd_lead_provider_name AS lead_provider_name
-    ,COALESCE(dec.cpd_delivery_partner_name, dec.delivery_partner_name) AS delivery_partner_name
+    ,COALESCE(dp.cpd_dp_name, dec.delivery_partner_name) AS delivery_partner_name
     ,dec.induction_record_id AS latest_induction_record_id
-    ,dec.school_urn AS induction_record_school_urn -- School URN of latest induction record.
+    ,dec.school_urn AS induction_record_school_urn -- School URN of latest induction record.    
     ,COALESCE(ind.school_urn, ind2.school_urn) AS declaration_date_school_urn -- School URN on the induction record valid on the declaration date.
     ,COALESCE(ind.induction_record_id, ind2.induction_record_id) AS induction_record_id_on_declaration_date
-    ,COALESCE(ind.school_urn, dec.school_urn) AS used_school_urn
+    ,COALESCE(ind.school_urn, ind2.school_urn, dec.school_urn) AS used_school_urn
     -- For each started, retained-1/2/3/4 or completed declaration 6 hours of funding is allocated.
     ,CASE
       WHEN dec.declaration_type IN ('started', 'retained-1', 'retained-2', 'retained-3', 'retained-4', 'completed') THEN 6
@@ -80,11 +80,11 @@ WITH declarations AS (
       WHEN ROW_NUMBER() OVER(PARTITION BY COALESCE(ind.school_urn, ind2.school_urn, dec.school_urn)) = 1 THEN 1
       ELSE 0
      END AS unique_school_urn_count
-    ,CASE
-      WHEN (ROW_NUMBER() OVER(PARTITION BY dec.declaration_id ORDER BY COALESCE(ind.start_date, ind2.start_date) DESC)) = 1 THEN 1
-      ELSE 0
+    ,CASE 
+      WHEN (ROW_NUMBER() OVER(PARTITION BY dec.declaration_id ORDER BY COALESCE(ind.start_date, ind2.start_date) DESC)) = 1 THEN 1 
+      ELSE 0 
      END AS rn0
-  FROM
+  FROM 
     ${ref('ecf_declarations')} AS dec
   LEFT JOIN
     ${ref('ecf_inductions')} AS ind
@@ -92,8 +92,7 @@ WITH declarations AS (
     ind.participant_profile_id = dec.participant_profile_id
     AND
     DATE(dec.declaration_date) BETWEEN DATE(ind.start_date) AND DATE(IFNULL(ind.end_date, '2050-12-31'))
-
-
+        
   LEFT JOIN
     ${ref('ecf_inductions')} ind2
   ON
@@ -102,6 +101,11 @@ WITH declarations AS (
     DATE(dec.declaration_date) < IFNULL(DATE(ind2.end_date), '2050-12-31')
     AND
     ind.induction_record_id IS NULL
+
+  LEFT JOIN
+    ${ref('ls_declarations_provider_names')} AS dp
+  ON
+    dp.id = dec.declaration_id
 
   WHERE
     funded_declaration = TRUE
@@ -115,17 +119,17 @@ WITH declarations AS (
 ),
 
 ects AS (
-  SELECT
+  SELECT 
      sch.urn
-    ,COUNT(1) AS school_ect_count
-  FROM
-    ${ref('participant_profiles_latest_cpd')} pp
+    ,COUNT(1) AS school_ect_count 
+  FROM 
+    ${ref('participant_profiles_latest_cpd')} AS pp
   LEFT JOIN
-    ${ref('school_cohorts_latest_cpd')} scho
+    ${ref('school_cohorts_latest_cpd')} AS scho
   ON
     scho.id = pp.school_cohort_id
   LEFT JOIN
-    ${ref('schools_latest_cpd')} sch
+    ${ref('schools_latest_cpd')} AS sch 
   ON
     sch.id = scho.school_id
   WHERE
@@ -134,7 +138,7 @@ ects AS (
     induction_completion_date IS NULL OR induction_completion_date > '2023-08-31'
   GROUP BY
     sch.urn
-  ORDER BY
+  ORDER BY 
     school_ect_count DESC
 ),
 
@@ -144,8 +148,7 @@ declarations_extended AS (
     ,ROW_NUMBER() OVER(PARTITION BY dec.participant_profile_id ORDER BY declaration_type_hierarchy ASC) AS declaration_sequence
     ,ROUND((cost.cost_for_36_hours / 36) * dec.funded_hours, 2) AS funded_hours_cost
     ,CASE
-      WHEN pp1.user_id IS NOT NULL THEN TRUE
-      WHEN pp2.user_id IS NOT NULL THEN TRUE
+      WHEN pp.user_id IS NOT NULL THEN TRUE
       ELSE FALSE
      END AS previously_paid
     ,gias.LA_Name AS local_authority
@@ -160,8 +163,8 @@ declarations_extended AS (
   FROM
     declarations dec
   LEFT JOIN
-    ects
-  ON
+    ects 
+  ON 
     ects.urn = dec.used_school_urn
   LEFT JOIN
     ${ref('establishments')} AS gias
@@ -172,21 +175,24 @@ declarations_extended AS (
   ON
     band.LA_code = CAST(gias.LA_code AS INT)
   LEFT JOIN
-    ${ref('ecf_mentors_previously_paid')} AS pp1
+    ${ref('ecf_mentors_previously_paid')} AS pp
   ON
-    pp1.user_id = dec.user_id
-    AND
-    dec.declaration_type IN ('started', 'retained-1', 'retained-2')
-    AND
-    pp1.payment_period LIKE 'Instalment 1%'
-  LEFT JOIN
-    ${ref('ecf_mentors_previously_paid')} AS pp2
-  ON
-    pp2.user_id = dec.user_id
-    AND
-    dec.declaration_type IN ('retained-3', 'retained-4', 'completed')
-    AND
-    pp2.payment_period LIKE 'Instalment 2%'
+    pp.user_id = dec.user_id
+    AND 
+    (
+      (
+        dec.declaration_type IN ('started', 'retained-1', 'retained-2')
+        AND
+        pp.payment_period LIKE 'Instalment 1%'
+      )
+      OR
+      (
+        dec.declaration_type IN ('retained-3', 'retained-4', 'completed')
+        AND
+        pp.payment_period LIKE 'Instalment 2%'
+      )
+    )
+
   LEFT JOIN
     ${ref('teacher_pay_band_36_hour_cost')} AS cost
   ON
@@ -202,5 +208,5 @@ SELECT
     WHEN previously_paid = FALSE THEN school_ect_count / (SUM(CASE WHEN previously_paid = FALSE THEN 1 ELSE 0 END) OVER(PARTITION BY used_school_urn))
     ELSE 0
    END AS fractional_ect_count
-FROM
+FROM 
   declarations_extended


### PR DESCRIPTION
As well as the introduction of 2 new marts there are also new declarations for static tables and the GIAS data coming from Teacher Services.

Also, the new valid_application field for npq_enrolments to allow for filitering out "Ghost" NPQ SENCO applications. And, adding the declaration Delivery Partner to the ecf_declarations.