### PR TITLE
Incorporated LP check for those reduced schedules that will only have…

### DIFF
--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_induction_lp_dedupe_start_decs.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_induction_lp_dedupe_start_decs.sqlx
@@ -251,6 +251,7 @@ END
   AS replacement_mentor_check,
   CASE
     WHEN lead_provider_name = started_cpd_lead_provider_name THEN TRUE
+    WHEN lead_provider_name = completed_cpd_lead_provider_name and REGEXP_CONTAINS(schedule_identifier,'reduced')) THEN TRUE
   ELSE
   FALSE
 END


### PR DESCRIPTION
… a completed declaration.

Simple tweak needed to incorporate a key check for matching lead providers. Currently only set up to accomodate standard schedules, this brings in reduced schedules too.