### PR TITLE
Added column for funded hours associated to uncapped declarations only.

### DIFF
--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
@@ -188,7 +188,7 @@ declarations_extended AS (
 SELECT
    * EXCEPT(rn0)
   -- Create column for adjusted funded hours where declaration sequence is 3 or less. Only 3 declarations can be funded in a single round of Grant Funding.
-  ,CASE WHEN declaration_sequence <= 3 THEN funded_hours ELSE 0 END AS capped_funded_hours
+  ,CASE WHEN declaration_sequence <= 3 AND previously_paid = FALSE THEN funded_hours ELSE 0 END AS capped_funded_hours
   -- Funded hours per school for mentors not previously paid aggregated at school level for relevant cases only.
   ,SUM(CASE WHEN previously_paid = FALSE AND declaration_sequence <= 3 THEN funded_hours ELSE 0 END) OVER(PARTITION BY used_school_urn) AS school_mentor_backfill_funded_hours
   -- School ECT count evenly distributed across rows for mentors who were not previously paid to enable aggregation at School level in the dashboard output.

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
@@ -37,6 +37,7 @@ config {
         gias_establishment_status: "The establishment status currently in GIAS for the used_school_urn.",
         school_mentor_count: "The aggregated count of mentors, using unique participant profile ids, for a given used_school_urn (where those mentors have not received prior payments).",
         school_ect_count: "The aggregated count of ECTs, using unique participant profile ids from ecf_inductions_dedupe, for a given used_school_urn (where those ECTS have an completed_date that is either null or after 31/08/2023).",
+        capped_funded_hours: "The funded hours per declaration where the declaration is one of the 3 allowed per Grant Funding period.",
         school_mentor_backfill_funded_hours: "The sum of funded hours for mentors for a given used_school_urn (where previously_paid if FALSE).",
         fractional_ect_count: "The ect_count for the used_school_urn split evenly across all rows of the mart where previously_paid is FALSE. This enables accurate summing to occur in the Looker Dashboard."
    }
@@ -186,8 +187,10 @@ declarations_extended AS (
 
 SELECT
    * EXCEPT(rn0)
+  -- Create column for adjusted funded hours where declaration sequence is 3 or less. Only 3 declarations can be funded in a single round of Grant Funding.
+  ,CASE WHEN declaration_sequence <= 3 THEN funded_hours ELSE 0 END AS capped_funded_hours
   -- Funded hours per school for mentors not previously paid aggregated at school level for relevant cases only.
-  ,SUM(CASE WHEN previously_paid = FALSE THEN funded_hours ELSE 0 END) OVER(PARTITION BY used_school_urn) AS school_mentor_backfill_funded_hours
+  ,SUM(CASE WHEN previously_paid = FALSE AND declaration_sequence <= 3 THEN funded_hours ELSE 0 END) OVER(PARTITION BY used_school_urn) AS school_mentor_backfill_funded_hours
   -- School ECT count evenly distributed across rows for mentors who were not previously paid to enable aggregation at School level in the dashboard output.
   ,CASE
     WHEN previously_paid = FALSE THEN school_ect_count / (SUM(CASE WHEN previously_paid = FALSE THEN 1 ELSE 0 END) OVER(PARTITION BY used_school_urn))

--- a/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npq_contract_management.sqlx
@@ -28,7 +28,7 @@ WITH
   SELECT
     lead_provider,
     course,
-    TARGET
+    target
   FROM
     ${ref('npq_lead_provider_course_targets')}
   WHERE
@@ -48,6 +48,13 @@ WITH
       NULL
     END
       ) AS accepted_applications,
+    COUNT(DISTINCT
+      CASE
+        WHEN application_status = 'accepted' AND funded_place = 'true' THEN application_ecf_id
+      ELSE
+      NULL
+    END
+      ) AS accepted_funded_applications,
     COUNT(DISTINCT
       CASE
         WHEN application_status = 'pending' THEN application_ecf_id


### PR DESCRIPTION
In order to remove the funded hours but still show the declarations the code has been amended to calculate the capped funded hours amount so that the school level aggregation is correct and the declaration level table still shows these declarations that are not to be funded in this round.