### PR TITLE
Changing Registration Window

### DIFF
--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_ect_inductions.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_ect_inductions.sqlx
@@ -49,7 +49,7 @@ FROM (
   SELECT
     DISTINCT(start_year) AS reg_year,
     CAST(CONCAT(start_year,'-05-01') AS date) AS reg_start_date,
-    CAST(CONCAT(start_year,'-10-31') AS date) AS reg_end_date
+    CAST(CONCAT(start_year,'-11-30') AS date) AS reg_end_date
   FROM
     ${ref("cohorts_latest_cpd")}
   WHERE

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_mentor_inductions.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_mentor_inductions.sqlx
@@ -44,7 +44,7 @@ FROM (
   SELECT
     DISTINCT(start_year) AS reg_year,
     CAST(CONCAT(start_year,'-05-01') AS date) AS reg_start_date,
-    CAST(CONCAT(start_year,'-10-31') AS date) AS reg_end_date
+    CAST(CONCAT(start_year,'-11-30') AS date) AS reg_end_date
   FROM
     ${ref("cohorts_latest_cpd")}
   WHERE

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_participant_inductions.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_participant_inductions.sqlx
@@ -37,7 +37,7 @@ FROM (
   SELECT
     DISTINCT(start_year) AS reg_year,
     CAST(CONCAT(start_year,'-05-01') AS date) AS reg_start_date,
-    CAST(CONCAT(start_year,'-10-31') AS date) AS reg_end_date
+    CAST(CONCAT(start_year,'-11-30') AS date) AS reg_end_date
   FROM
     ${ref("cohorts_latest_cpd")}
   WHERE

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_school_cohorts.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_reg_school_cohorts.sqlx
@@ -238,7 +238,7 @@ FROM (
   SELECT
     DISTINCT(start_year) AS reg_year,
     CAST(CONCAT(start_year,'-05-01') AS date) AS reg_start_date,
-    CAST(CONCAT(start_year,'-10-31') AS date) AS reg_end_date
+    CAST(CONCAT(start_year,'-11-30') AS date) AS reg_end_date
   FROM
     ${ref("cohorts_latest_cpd")}) AS start_years
 CROSS JOIN


### PR DESCRIPTION
The ECF registration marts have been based on the end of registration being 31/10 but it's still helpful to see registrations after that date so pushing the window to 30/11.