### PR TITLE
TAD Table Re-Design

### DIFF
--- a/definitions/marts/npq_separation_prep/tad_npq_enrolment_v2.sqlx
+++ b/definitions/marts/npq_separation_prep/tad_npq_enrolment_v2.sqlx
@@ -12,12 +12,12 @@ config {
     },
     description: "This table is designed around NPQ Applications with each application constituting a single record. Participant details have been joined into the application record.",
     columns: {
-        application_id: "This is the unique id for an NPQ application, previously called application_ecf_id. We join this field on the application_id field in the declarations table to identify declarations paired with this application",
-        teacher_profile_trn: "This TRN is sourced through user profiles (previously Teacher Profiles) which are dependent on the application having been accepted by a Lead Provider. If the application has been made but has yet to be accepted the TRN field will be blank despite a valid TRN verified field. ",
-        // user_id: "This User ID is sourced through user profiles which are dependent on the application having been accepted by a Lead Provider. If the application has been made but has yet to be accepted the User ID field will be blank.",
+        application_id: "This is the unique id for an NPQ applications. This field was entirely generated post-separation in the new NPQ data model. We join this field on the application_id field in the declarations table to identify declarations paired with this application. This field will not map onto historical application_ids generated prior to NPQ Separation (27/11/2024). If you would like to map historical application_ids please use the application_ecf_id field that hosts historical application_ids",
+        application_ecf_id: "This field contains the historical application_id that will have been created in the old data model pre-separation. This field is available in the new model but not used to join on other tables.  You can use this field if you want to map historical data that pre-dates the ECF & NPQ separation (27/12/2024).",
+        teacher_profile_trn: "This TRN is sourced through user profiles (previously Teacher Profiles). If the application has been made but the TRN has not been fully verified the TRN field will be blank despite a valid TRN auto_verified field.",
         participant_user_id: "This is the user_id that matches the user_ids created pre-separation in the ECF Teacher Profiles. This field can be used to join on ECF Teacher Profiles should they have an ECF profile or were present in NPQ data prior to 28/11/2024. This user_id is sourced from the NPQ User Profile.",
-        application_trn: "This is the TRN provided at the point of application",
-        trn_auto_verified: "This refers to whether the TRN provided in the application process was verified",
+        application_trn: "This is the TRN provided by applicants at the point of application, if a teacher_profile_trn is available that is the preferred source for a TRN as this field could have been incorrectly completed at the time of the application.  The teacher_profile_trn field contains the verified approved TRN for an individual once the appropriate checks have occurred.",
+        trn_auto_verified: "This refers to whether the TRN provided in the application process was automatically verified in the application process",
         headteacher_status: "Indicates whether the participant is a headteacher in their first five years.",
         eligible_for_funding: "Indicates whether the applicant is eligible for funding for their course.",
         funding_choice: "If a participant is not eligible for funding, this indicates the source of the funding for their NPQ. Possible fields: Another, School, Self, Trust ",
@@ -37,7 +37,7 @@ config {
         employment_type: "For non-school users, shows the type of institution they are employed in. Possible fields: Local authority supply teachers, Local authority virtual school, Young offender institute, Hospital school, Other",
         training_status: "Pulled from participant profile which is created when application is accepted by lead provider ",
         schedule_identifier: "This indicates which sub-cohort or tranche the participant commenced training within an annual cohort. For NPQ, the schedule identifier also distinguishes between the leadership and specialist NPQ types. Pulled from participant profile which is created when application is accepted by lead provider",
-        lead_provider_id: "Pulled from the NPQ application record",
+        lead_provider_id: "Pulled from the NPQ application record. Please note values in this field will not match the same numerical value available in your historical snapshots but the lead provider has not changed.",
         primary_establishment: "Records whether the user's establishment at time of registration was a primary establishment or not. Based on GIAS data.",
         teacher_catchment: "The catchment zone the participant works in within the UK i.e. England, Wales, Northern Ireland etc. International applicants recorded as 'another'",
         teacher_catchment_country: "The country the participant works in ",
@@ -47,12 +47,11 @@ config {
     }
 }
 
-
 SELECT
   application_id,
+  application_ecf_id,
   trn_verified AS teacher_profile_trn,
-  -- user_id, # Inclusion to be reviewed post separation
-  ecf_user_id as participant_user_id,
+  ecf_user_id AS participant_user_id,
   application_trn,
   trn_auto_verified,
   application_created_at,

--- a/definitions/marts/npq_separation_prep/tad_participant_outcomes_v2.sqlx
+++ b/definitions/marts/npq_separation_prep/tad_participant_outcomes_v2.sqlx
@@ -12,10 +12,11 @@ config {
     },
     description: "This table contains all course outcomes and is relevant for NPQ participants only",
     columns: {
-        outcome_id: "UID",
+        outcome_id: "This is the unique id for an NPQ outcome. This field was entirely generated post-separation in the new NPQ data model. We join this field on the declaration_id field in the declarations table to identify declarations paired with these outcomes. This field will not map onto historical outcome_ids generated prior to NPQ Separation (27/11/2024). If you would like to map historical outcome_ids please use the outcome_ecf_id field that hosts historical outcome_ids ",
+        outcome_ecf_id: "This field contains the historical outcome_id that will have been created in the old data model pre-separation. This field is available in the new model but not used to join on other tables.  You can use this field if you want to map historical data that pre-dates the ECF & NPQ separation (27/12/2024).",
         created_at: "Date this entity was created according to the latest version of the data received from the database.",
         updated_at: "Date this entity was last updated something in the database, according to the latest version of the data received from the database.",
-        participant_declaration_id: "Field used to join with relevant declarations"
+        participant_declaration_id: "This is the declaration id for a given outcome. You can map this field onto declaration_id in the declarations table."
 
     }
 }
@@ -23,15 +24,11 @@ config {
 
 SELECT
   outcomes.id as outcome_id,
+  outcomes.ecf_id AS outcome_ecf_id,
   outcomes.created_at,
   outcomes.updated_at,
   outcomes.completion_date,
   outcomes.declaration_id AS participant_declaration_id,
-  -- dec.ecf_id AS declaration_ecf_id, # To be reviewed post separation if GUID is required for exposure.
   outcomes.state
 FROM
   ${ref(`participant_outcomes_latest_npq`)} AS outcomes
-LEFT JOIN
-    ${ref('declarations_latest_npq')} AS dec
-ON
-    dec.id = outcomes.declaration_id

--- a/definitions/marts/tad_marts/tad_npq_participant_declarations.sqlx
+++ b/definitions/marts/tad_marts/tad_npq_participant_declarations.sqlx
@@ -12,17 +12,14 @@ config {
     },
     description: "This table contains all declaration records for NPQ participants",
     columns: {
-        declaration_id: "UID",
+        declaration_id: "This is the unique id for an NPQ declarations. This field was entirely generated post-separation in the new NPQ data model. We join this field on the declaration_id field in the outcomes table to identify outcomes paired with this declaration. This field will not map onto historical declaration_ids generated prior to NPQ Separation (27/11/2024). If you would like to map historical declaration_ids please use the declaration_ecf_id field that hosts historical declaration_ids",
+        declaration_ecf_id: "This field contains the historical declaration_id that will have been created in the old data model pre-separation. This field is available in the new model but not used to join on other tables.  You can use this field if you want to map historical data that pre-dates the ECF & NPQ separation (27/12/2024).",
         created_at: "Date this entity was created, according to the latest version of the data received from the database.",
         updated_at: "Date this entity was last updated something in the database, according to the latest version of the data received from the database.",
-        course_identifier: "Identifier of the NPQ course the declaration relates to.",
         lead_provider_name: "The name of the Lead Provider who submitted the declaration.",
         declaration_date: "Date evidence was received.",
         declaration_type: "The declaration type which for NPQ can be started, retained-1, retained-2 or completed.",
-        // application_id: "ID used to link to NPQ Enrolments (application_id)",
-        application_ecf_id: " ID used to link to NPQ Enrolments (application_id)",
-        // user_id: "ID from the new NPQ Service (as of 28/11/2024) for the user who has been declared against. Use this to link to User Profiles (user_id).",
-        participant_user_id: "ECF ID of the user who has been declared against. Use this to join with Teacher Profiles (user_id). If the user has no ECF presence or only appeared in NPQ data after 27/11/2024, they will not appear in Teacher Profiles.",
+        application_id: "This is the ID generated for applications in the new separated NPQ Environment. This field should be used to join on application_id when joining with enrolment data. This field will not map onto historical application_ids generated prior to NPQ Separation (27/11/2024).",
         state: "The current state of the declaration.",
         last_streamed_event_occurred_at: "Timestamp of the event that we think provided us with the latest version of this entity.",
         last_streamed_event_type: "Event type of the event that we think provided us with the latest version of this entity. Either entity_created, entity_updated, entity_destroyed or entity_imported."
@@ -33,17 +30,14 @@ config {
 
 SELECT
   dec.id as declaration_id,
+  dec.ecf_id as declaration_ecf_id,
+  dec.application_id,
   dec.created_at,
   dec.updated_at,
-  course.identifier AS course_identifier,
   dec.lead_provider_id,
   lead_providers.name AS lead_provider_name,
   declaration_date,
   declaration_type,
-  -- applications.id AS application_id,
-  applications.ecf_id AS application_ecf_id,
-  -- users.id AS user_id
-  users.ecf_id AS participant_user_id,
   state,
   dec.last_streamed_event_occurred_at,
   dec.last_streamed_event_type
@@ -53,16 +47,3 @@ LEFT JOIN
   ${ref(`lead_providers_latest_npq`)} AS lead_providers
 ON
   dec.lead_provider_id = lead_providers.id
-LEFT JOIN
-  ${ref('applications_latest_npq')} AS applications
-ON
- applications.id = dec.application_id
-LEFT JOIN
-  ${ref('courses_latest_npq')} AS course
-ON
-  course.id = applications.course_id
-LEFT JOIN
-  ${ref('users_latest_npq')} AS users
-ON
-  users.id = applications.user_id
-


### PR DESCRIPTION
I've modified the TAD marts to fundamentally simplify the logic so that we aren't pulling together multiple tables to recreate historical data models on TAD's behalf. Instead, I have deprecated the fields that no longer come through on declarations and ensured those fields are available only in the enrolments table. TAD will then be able to join the tables to get the fields they need. I've also ensured the key historical primary ids are made available as 'ecf_ids' so that they can cross-check historical records.