### PR TITLE
Field Description Change + Unique Record Identifier Update

### DIFF
--- a/definitions/marts/bigquery_marts/ecf2/ecf2_teacher_induction_periods.sqlx
+++ b/definitions/marts/bigquery_marts/ecf2/ecf2_teacher_induction_periods.sqlx
@@ -30,7 +30,7 @@ config {
         trs_initial_teacher_training_end_date: "Date an ECT finished their ITT held on TRS",
         trs_initial_teacher_training_provider_name: "ECT's ITT provider name held on TRS",
         trs_qts_status_description: "ECT's QTS status held on TRS",
-        record_origin: "This identifies where the first version of the induction period came from: whether it was imported prior to the service going live (imported), or if it was created by an AB (user_created) or a Support Team member (admin_created) - Currently, the system is supposed to block admin users from creating induction periods so no records should return this. ",
+        record_creator: "This identifies where the first version of the induction period came from: whether it was imported prior to the service going live (imported), or if it was created by an AB (user_created) or a Support Team member (admin_created) - Currently, the system is supposed to block admin users from creating induction periods so no records should return this. ",
         non_admin_update_flag: "This boolean flags if the induction period has been updated by an AB (non-admin) user",
         admin_update_flag: "This boolean flags if the induction period has been updated by an support team (admin) user"
     }

--- a/definitions/marts/looker_studio_marts/ecf2/ls_ecf2_induction_period_edits.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf2/ls_ecf2_induction_period_edits.sqlx
@@ -1,7 +1,7 @@
 config {
     type: "table",
     assertions: {
-        uniqueKey: ["induction_period_id"]
+        uniqueKey: ["update_id"]
     },
     bigquery: {
         partitionBy: "DATE(update_timestamp)",
@@ -23,6 +23,7 @@ WITH
   induction_updates AS (
   SELECT
     entity_id,
+    update_id,
     occurred_at,
     CASE
       WHEN request_path LIKE '%admin%' THEN TRUE
@@ -45,6 +46,7 @@ SELECT
   number_of_terms,
   outcome,
   qts_awarded_on,
+  update_id,
   field_updated,
   induction_updates.occurred_at AS update_timestamp,
   previous_value,


### PR DESCRIPTION
I changed the name of a field so I needed to change the name of the field in the corresponding description.

Also, with the induction periods update mart I couldn't use the induction period id as the primary key so I switched it to the update_id