### PR TITLE
Tag hidden PII in custom fields

### DIFF
--- a/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_declarations.sqlx
@@ -10,7 +10,11 @@ config {
         participant_course: "This is a shortened version of participant_type",
         cpd_delivery_partner_name: "The name of the Delivery Partner taken from the declaration record rather than the induction record.",
         statement_id: "The ID of the financial statement which the declaration belongs to.",
-        statement_cohort: "The start_year of the cohort associated with the financial statement the declaration belongs to. This can differ to the participants cohort and is often used when assessing declaration level KPIs as these cannot change whereas a participant can move between academic cohorts."
+        statement_cohort: "The start_year of the cohort associated with the financial statement the declaration belongs to. This can differ to the participants cohort and is often used when assessing declaration level KPIs as these cannot change whereas a participant can move between academic cohorts.",
+        trn: {
+            description: "TRN for the teacher this declaration related to training for",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
     }
 }
 

--- a/definitions/marts/bigquery_marts/ecf/ecf_golden_thread.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_golden_thread.sqlx
@@ -10,7 +10,11 @@ config {
     description: "This mart joins the latest induction record for a given ECF participant (found in the ecf_inductions_dedupe mart) with a golden thread of ecf declarations (started, retained-1, retained-2, retained-3, retained-4 and completed). In order to determine the preferred declaration for each declaration type we've determined a preferred state_hierarchy:paid>payable>eligible>submitted>clawed_back>awaiting_clawback>voided ",
     columns: {
         induction_record_id: "ID of individual induction record",
-        declaration_participant_profile_id: "ID used to join declarations to each other and used to join with inductions mart"
+        declaration_participant_profile_id: "ID used to join declarations to each other and used to join with inductions mart",
+        trn: {
+            description: "TRN of this participant",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
     }
 }
 

--- a/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_inductions.sqlx
@@ -34,7 +34,10 @@ config {
         induction_record_created_at: "When this induction record was generated.",
         partnership_id: "ID for the Lead Provider-School partnership for a given cohort.",
         partnership_relationship: "TRUE/FALSE for the partnership_id taken from partnerships_latest_cpd. The relationship is 'live' when the value returns FALSE.",
-        TRN: "This comes from a participant's teacher profile.",
+        TRN: {
+            description: "This comes from a participant's teacher profile.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         cohort: "The cohort/academic year corresponding to when the participant started their course. Possible fields: 2021 onwards.",
         school_id: "ID of the participant's school.",
         high_pupil_premium: "This indicates whether the uplift payment for X is applicable to this participant's started declaration",

--- a/definitions/marts/bigquery_marts/ecf/ecf_inductions_dedupe.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_inductions_dedupe.sqlx
@@ -33,7 +33,10 @@ config {
         participant_type: "Either ECT or Mentor",
         induction_record_created_at: "When this induction record was generated.",
         partnership_id: "ID for the Lead Provider-School partnership for a given cohort.",
-        TRN: "This comes from a participant's teacher profile.",
+        TRN: {
+            description: "This comes from a participant's teacher profile.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         cohort: "The cohort/academic year corresponding to when the participant started their course. Possible fields: 2021 onwards.",
         school_id: "ID of the participant's school.",
         high_pupil_premium: "This indicates whether the uplift payment for X is applicable to this participant's started declaration",

--- a/definitions/marts/bigquery_marts/ecf2/ecf2_teacher_induction_periods.sqlx
+++ b/definitions/marts/bigquery_marts/ecf2/ecf2_teacher_induction_periods.sqlx
@@ -24,7 +24,10 @@ config {
         outcome: "ECT's overall induction outcome",
         induction_period_created_at: "Date and time an induction period was created by an AB",
         induction_period_updated_at: "Date and time an induction period was updated by an AB",
-        trn: "A unique 7-digit Teacher Reference Number",
+        trn: {
+            description: "A unique 7-digit Teacher Reference Number",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         induction_start_date_submitted_to_trs_at: "Date and time an induction start date was submitted to TRS for an ECT",
         trs_induction_status: "Overall induction status held on the TRS",
         trs_initial_teacher_training_end_date: "Date an ECT finished their ITT held on TRS",

--- a/definitions/marts/bigquery_marts/npq/npq_enrolments.sqlx
+++ b/definitions/marts/bigquery_marts/npq/npq_enrolments.sqlx
@@ -11,8 +11,14 @@ config {
     columns: {
         application_id: "ID of each unique application in the new NPQ Service. Declarations are joined to the application using this id",
         application_ecf_id: "ECF ID of each unique application. This is the GUID version which can be found in participant_declarations_latest_cpd if created before 28/11/2024.",
-        application_trn: "This is either the application_trn as per the NPQ Application record in the ECF Service prior to separation, or the first TRN associated with the user profile at the time the application was created. The user profile is created when the applicant first applies and the TRN field is populated with the value provided before any verification takes place. We use the valid record on the users table to determine the TRN provided at the time of application as this is overwritten in the user profile with the verified TRN if it is different. If a user re-applies after their user profile is created the service does not record their entered TRN again but instead uses the one on file.",
-        trn_verified: "This is the TRN sourced from the User Profile",
+        application_trn: {
+            description: "This is either the application_trn as per the NPQ Application record in the ECF Service prior to separation, or the first TRN associated with the user profile at the time the application was created. The user profile is created when the applicant first applies and the TRN field is populated with the value provided before any verification takes place. We use the valid record on the users table to determine the TRN provided at the time of application as this is overwritten in the user profile with the verified TRN if it is different. If a user re-applies after their user profile is created the service does not record their entered TRN again but instead uses the one on file.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
+        trn_verified: {
+            description: "This is the TRN sourced from the User Profile",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         trn_auto_verified: "This refers to whether the TRN provided in the application process was verified.",
         application_created_at: "Refers to the date the application was created.",
         headteacher_status: "Indicates whether the participant is a headteacher in their first five years.",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_cohort_corruption_checker.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_cohort_corruption_checker.sqlx
@@ -35,7 +35,10 @@ config {
         cpd_dp_name: "Name of Delivery Partner for ECF course",
         programme: "Shortening of 'type'. Says if it belongs to either the ECF or NPQ programme.",
         suggested_cohort_from_declaration: "Calculates where a declaration date falls in the declaration milestone window across an entire cohor and therefore the suggested cohort.",
-        check_source: "Details which (if any) of the checks a declaration belongs to."
+        check_source: "Details which (if any) of the checks a declaration belongs to.",
+        verified_trn: {
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
     }
 }
 

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_induction_lp_dedupe_start_decs.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_induction_lp_dedupe_start_decs.sqlx
@@ -34,7 +34,10 @@ config {
         participant_type: "Longform version of either ECT or Mentor",
         induction_record_created_at: "When this induction record was generated.",
         partnership_id: "ID for the Lead Provider-School partnership for a given cohort.",
-        TRN: "This comes from a participant's teacher profile.",
+        TRN: {
+            description: "This comes from a participant's teacher profile.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         cohort: "The cohort/academic year corresponding to when the participant started their course. Possible fields: 2021 onwards. This is pulled from the started declaration of the participant (or the completed declaration if no started declaration is available). This is because the cohort might have changed at induction record level for a participant but the declaration will still be associated with the cohort that was accurate when the declaration was raised.",
         school_id: "ID of the participant's school.",
         high_pupil_premium: "This indicates whether the uplift payment for X is applicable to this participant's started declaration",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_induction_start_date.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_induction_start_date.sqlx
@@ -11,7 +11,10 @@ config {
     columns: {
         user_id: "User ID of the ECT.",
         participant_profile_id: "ID of each ECT's profile.",
-        trn: "TRN associated with the ECT's profile.",
+        trn: {
+            description: "TRN associated with the ECT's profile.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         participant_type_short: "Shows the participant as an ECT.",
         cohort: "Cohort of the ECT.",
         schedule_identifier: "Schedule of the ECT.",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
@@ -12,7 +12,10 @@ config {
         declaration_id: "The unique identifier of the declaration.",
         participant_profile_id: "The id of the participant associated with the declaration.",
         user_id: "This comes from the teacher profile associated with the participant profile.",
-        TRN: "This comes from a participant's teacher profile.",
+        trn: {
+            description: "This comes from a participant's teacher profile.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         declaration_type: "The type of declaration which can be started, retained-1/2/3/4, extended-1/2/3 or completed.",
         declaration_state: "The state of the declaration which for this mart can only be funded (eligible/payable/paid)",
         declaration_type_hierarchy: "A number from 1 to 9 based on started to completed declaration types to enable sorting in the correct sequence regardless of declaration date.",

--- a/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
@@ -18,7 +18,16 @@ config {
         response_status: "The code associated with the API call. Any non-200 response status is an error.",
         lp_name: "Name of the Lead Provider making the API call.",
         request_body: "Details the call made by the Lead Provider.",
-        response_body: "Details the API response. Usually populated if there are any errors with the API call being made."
+        response_body: "Details the API response. Usually populated if there are any errors with the API call being made.",
+        hidden_DATA: {
+          columns: {
+            key: "Name of a field containing sensitive data included in this API request custom event from dfe-analytics",
+            value: {
+              description: "Contents of this field",
+              bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+            }
+          }
+        }
     }
 }
 

--- a/definitions/marts/looker_studio_marts/ls_declarations_provider_names.sqlx
+++ b/definitions/marts/looker_studio_marts/ls_declarations_provider_names.sqlx
@@ -38,7 +38,10 @@ config {
         cpd_dp_name: "Name of Delivery Partner for ECF course",
         programme: "Either ECF or NPQ based on which source the data originates from.",
         application_id: "NPQ ONLY. The unique identifier of the application the declaration relates to. A unique count of this field provides the number of NPQ courses included within the data.",
-        verified_trn: "The TRN of the participant that has been verified by the Database of Qualified Teachers (DQT)."
+        verified_trn: {
+            description: "The TRN of the participant that has been verified by the Database of Qualified Teachers (DQT).",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        }
     }
 }
 

--- a/definitions/marts/looker_studio_marts/npq/ls_npq_tsf_application_detail.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npq_tsf_application_detail.sqlx
@@ -13,8 +13,14 @@ config {
       To obtain list of currently not included applications that meet review criteria: is_included = 0 AND is_excluded = 0 AND(pupils_at_reg_chk = 1 OR gias_pupils_chk = 1 OR gias_phase_chk = 1 OR spec_est_chk = 1)",
     columns: {
         ecf_user_id: "This comes from the teacher profile associated with the participant profile. User ID also exists independently in other tables.",
-        application_trn: "This is the TRN provided at the point of application",
-        verified_trn: "This is the TRN from the Teacher Profile associated with the ecf_user_id",
+        application_trn: {
+            description: "This is the TRN provided at the point of application",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
+        verified_trn: {
+            description: "This is the TRN from the Teacher Profile associated with the ecf_user_id",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         application_id: "ID of each unique application. Declarations are joined to the application using this id and it is also the participant_profile_id in the declarations table",
         course_identifier: "Shorthand of NPQ course. This comes from the participant's latest declaration. EHCO & ASO are excluded from the output.",
         cohort: "The cohort/academic year corresponding to when the participant started their course.",

--- a/definitions/marts/looker_studio_marts/npq/ls_npqeyl_enrolments.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npqeyl_enrolments.sqlx
@@ -10,8 +10,14 @@ config {
     description: "This mart provides a report of all Early Years Leadership NPQs (NPQEYL). The table links to fields from GIAS and Ofsted establishments and feeds into the NPQEYL dashboard.",
     columns: {
         application_id: "ID of each unique application. Declarations are joined to the application using this id.",
-        application_trn: "This is the TRN provided at the point of application.",
-        trn_verified: "This is the TRN sourced from the teacher's profile via participant profiles",
+        application_trn: {
+            description: "This is the TRN provided at the point of application",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
+        trn_verified: {
+            description: "This is the TRN sourced from the teacher's profile via participant profiles",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         trn_auto_verified: "This refers to whether the TRN provided in the application process was verified.",
         application_created_at: "Refers to the date the application was created.",
         headteacher_status: "Indicates whether the participant is a headteacher in their first five years.",

--- a/definitions/marts/npq_separation_prep/tad_npq_enrolment_v2.sqlx
+++ b/definitions/marts/npq_separation_prep/tad_npq_enrolment_v2.sqlx
@@ -14,9 +14,15 @@ config {
     columns: {
         application_id: "This is the unique id for an NPQ applications. This field was entirely generated post-separation in the new NPQ data model. We join this field on the application_id field in the declarations table to identify declarations paired with this application. This field will not map onto historical application_ids generated prior to NPQ Separation (27/11/2024). If you would like to map historical application_ids please use the application_ecf_id field that hosts historical application_ids",
         application_ecf_id: "This field contains the historical application_id that will have been created in the old data model pre-separation. This field is available in the new model but not used to join on other tables.  You can use this field if you want to map historical data that pre-dates the ECF & NPQ separation (27/12/2024).",
-        teacher_profile_trn: "This TRN is sourced through user profiles (previously Teacher Profiles). If the application has been made but the TRN has not been fully verified the TRN field will be blank despite a valid TRN auto_verified field.",
+        teacher_profile_trn: {
+            description: "This TRN is sourced through user profiles (previously Teacher Profiles). If the application has been made but the TRN has not been fully verified the TRN field will be blank despite a valid TRN auto_verified field.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         participant_user_id: "This is the user_id that matches the user_ids created pre-separation in the ECF Teacher Profiles. This field can be used to join on ECF Teacher Profiles should they have an ECF profile or were present in NPQ data prior to 28/11/2024. This user_id is sourced from the NPQ User Profile.",
-        application_trn: "This is the TRN provided by applicants at the point of application, if a teacher_profile_trn is available that is the preferred source for a TRN as this field could have been incorrectly completed at the time of the application.  The teacher_profile_trn field contains the verified approved TRN for an individual once the appropriate checks have occurred.",
+        application_trn: {
+            description: "This is the TRN provided by applicants at the point of application, if a teacher_profile_trn is available that is the preferred source for a TRN as this field could have been incorrectly completed at the time of the application.  The teacher_profile_trn field contains the verified approved TRN for an individual once the appropriate checks have occurred.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         trn_auto_verified: "This refers to whether the TRN provided in the application process was automatically verified in the application process",
         headteacher_status: "Indicates whether the participant is a headteacher in their first five years.",
         eligible_for_funding: "Indicates whether the applicant is eligible for funding for their course.",

--- a/definitions/marts/tad_marts/tad_ecf_induction_records.sqlx
+++ b/definitions/marts/tad_marts/tad_ecf_induction_records.sqlx
@@ -15,7 +15,10 @@ config {
     columns: {
         induction_record_id: "ID of individual induction record",
         participant_profile_id: "This field is used to join with declarations and sourced from participant profiles. Participant profiles are automatically generated for ECTs/Mentors when induction tutors register the ECT/Mentor details. (NPQ participant profiles are generated differently). Due to the possibility (even likelihood) of multiple induction records, it's important to join declarations into induction records (instead of the other way around)",
-        TRN: "This comes from a participant profile",
+        TRN: {
+            description: "This comes from a participant profile",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         user_id: "This comes from the teacher profile associated with the participant profile",
         induction_programme_type: "The induction programme the school offers (FIP / CIP / DIY) : potential values: full_induction_programme core_induction_programme, design_our_own, school_funded_fip ",
         schedule_identifier: "This indicates which sub-cohort or tranche the participant commenced training within an annual cohort. For ECF, the schedule identifier also indicates if a participant is following a non-standard training route at any point (e.g. extended or reduced)",

--- a/definitions/marts/tad_marts/tad_npq_enrolment.sqlx
+++ b/definitions/marts/tad_marts/tad_npq_enrolment.sqlx
@@ -13,9 +13,15 @@ config {
     description: "This table is designed around NPQ Applications with each application constituting a single record. Participant details have been joined into the application record.",
     columns: {
         application_id: "This is the unique id for an NPQ application. We join this field on the participant_profile_id field in the declarations table to identify declarations paired with this application",
-        teacher_profile_trn: "This TRN is sourced through participant profiles which are dependent on the application having been accepted by a Lead Provider. If the application has been made but has yet to be accepted the TRN field will be blank despite a valid TRN verified field. ",
+        teacher_profile_trn: {
+            description: "This TRN is sourced through participant profiles which are dependent on the application having been accepted by a Lead Provider. If the application has been made but has yet to be accepted the TRN field will be blank despite a valid TRN verified field.",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         participant_user_id: "This User ID is sourced through teacher profiles which are dependent on the application having been accepted by a Lead Provider. If the application has been made but has yet to be accepted the User ID field will be blank. ",
-        application_trn: "This is the TRN provided at the point of application",
+        application_trn: {
+            description: "This is the TRN provided at the point of application",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
         trn_auto_verified: "This refers to whether the TRN provided in the application process was verified",
         headteacher_status: "Indicates whether the participant is a headteacher in their first five years.",
         eligible_for_funding: "Indicates whether the applicant is eligible for funding for their course.",

--- a/definitions/marts/tad_marts/tad_teacher_profiles.sqlx
+++ b/definitions/marts/tad_marts/tad_teacher_profiles.sqlx
@@ -12,6 +12,10 @@ config {
     description: "This table contains the mapping of user_id to TRN. There is not a perfect 1-to-1 relationship between user_id and TRN, there are cases of multiple records of user ids for a single TRN. There are no recorded cases of multiple TRNs for a single urn. \n \
     The user_id of NPQ participants who first appeared in NPQ data post 27/11/2024 will not appear in this table, instead please refer to NPQ User Profiles. These participants will not have had a Teacher Profile before 27/11/2024 and will only exist as users in the NPQ User Profiles Table.",
     columns: {
+        TRN: {
+            description: "7-digit Teacher Reference Number for this teacher",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
     }
 }
 


### PR DESCRIPTION
Note:

1. This will cause any dashboards using the normal Looker Studio service account (data-studio-cpd@ecf-bq.iam.gserviceaccount.com) to show hashed versions of the hidden PII instead of the raw data. After merging we should go through and switch any dashboards like this which need access to hidden PII over to using looker-studio-hidden-pii@ecf-bq.iam.gserviceaccount.com instead.
2. I also need to grant access to raw PII to the TAD service account.
3. I've hidden NPQ TRNs even though their dfe-analytics doesn't hide them. We also need to switch their dfe-analytics over but that can't be done as part of this PR.