### PR TITLE
Bring ITT and ECF mentor data together into a mart to power a dashboard

### DIFF
--- a/definitions/declarations/itt_mentor_claims.sqlx
+++ b/definitions/declarations/itt_mentor_claims.sqlx
@@ -1,0 +1,5 @@
+config {
+  type: "declaration",
+  schema: "itt_mentor_imported",
+  name: "itt_mentor_claims"
+}

--- a/definitions/marts/itt_mentor_marts/itt_mentor_ecf_mentors_and_providers.sqlx
+++ b/definitions/marts/itt_mentor_marts/itt_mentor_ecf_mentors_and_providers.sqlx
@@ -1,10 +1,11 @@
 config {
-    schema: "itt_mentor",
+    schema: dataform.projectConfig.schemaSuffix ? "dataform" : "itt_mentor",
     database: "ecf-bq",
     name: "ecf_mentors_and_providers",
     type: "table",
     assertions: {
-        uniqueKey: ["TRN", "provider_name"]
+        uniqueKey: ["TRN", "provider_name"],
+        rowConditions: ['provider_name IN ("Ambition Institute", "Best Practice Network", "Education Development Trust", "National Institute of Teaching", "Teach First", "UCL Institute of Education", "Capita")']
     },
     bigquery: {
         partitionBy: "first_completed_funded_mentor_training_with_this_lead_provider_on"
@@ -23,7 +24,7 @@ config {
 }
 
 SELECT
-  TRN,
+  CAST(TRN AS STRING) AS TRN,
   cpd_lead_provider_name AS provider_name, /* Remove CPD-specific jargon of lead providers here */
   CAST(MIN(start_date) AS DATE) AS first_started_funded_mentor_training_on,
   MIN(

--- a/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
+++ b/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
@@ -43,28 +43,32 @@ SELECT
     ELSE "Error in query logic - please report"
 END
   AS mentor_type,
-  CONCAT(
-    EXTRACT(YEAR FROM(MIN(ecf_mentor_provider.first_started_funded_mentor_training_on))) - 
-    IF(EXTRACT(MONTH FROM MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)) < 9, 1, 0),
-    '-',
-    RIGHT(
-        CAST(
-        EXTRACT(YEAR FROM(MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)))
-            - IF(EXTRACT(MONTH FROM MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)) < 9, 1, 0) + 1 AS STRING
-        ), 2
-    )
-    ) AS AY_first_started_funded_ecf_mentor_training_in,
-  CONCAT(
-    EXTRACT(YEAR FROM(MIN(earliest_claim_submitted_at))) - 
-    IF(EXTRACT(MONTH FROM MIN(earliest_claim_submitted_at)) < 9, 1, 0),
-    '-',
-    RIGHT(
-        CAST(
-        EXTRACT(YEAR FROM(MIN(earliest_claim_submitted_at)))
-            - IF(EXTRACT(MONTH FROM MIN(earliest_claim_submitted_at)) < 9, 1, 0) + 1 AS STRING
-        ), 2
-    )
-    ) AS AY_earliest_itt_mentor_training_funding_claim_submitted_in
+  IFNULL(
+    CONCAT(
+      EXTRACT(YEAR FROM(MIN(ecf_mentor_provider.first_started_funded_mentor_training_on))) - 
+      IF(EXTRACT(MONTH FROM MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)) < 9, 1, 0),
+      '-',
+      RIGHT(
+          CAST(
+          EXTRACT(YEAR FROM(MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)))
+              - IF(EXTRACT(MONTH FROM MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)) < 9, 1, 0) + 1 AS STRING
+          ), 2
+      )
+      ),
+    "Has not received funded ECF mentor training") AS AY_first_started_funded_ecf_mentor_training_in,
+  IFNULL(
+    CONCAT(
+      EXTRACT(YEAR FROM(MIN(earliest_claim_submitted_at))) - 
+      IF(EXTRACT(MONTH FROM MIN(earliest_claim_submitted_at)) < 9, 1, 0),
+      '-',
+      RIGHT(
+          CAST(
+          EXTRACT(YEAR FROM(MIN(earliest_claim_submitted_at)))
+              - IF(EXTRACT(MONTH FROM MIN(earliest_claim_submitted_at)) < 9, 1, 0) + 1 AS STRING
+          ), 2
+      )
+    ),
+    "Has not received funded ITT mentor training") AS AY_earliest_itt_mentor_training_funding_claim_submitted_in
 FROM
   ${ref("ecf_mentors_and_providers")} AS ecf_mentor_provider
 FULL JOIN

--- a/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
+++ b/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
@@ -1,0 +1,77 @@
+config {
+    database: "ecf-bq",
+    name: "mentors_and_providers_itt_ecf_combined",
+    type: "table",
+    assertions: {
+        uniqueKey: ["TRN", "provider_name"]
+    },
+    description: "Summary data about the relationship between each Early Careers Framework (ECF) or Initial Teacher Training (ITT) mentor and each organisation (provider) which received direct funding from DfE for training them to be a mentor.\nEach row is a relationship between one mentor and one such provider.\nIntended to used to analyse overlaps between teachers who have been trained by the same provider to be both ECF and Initial Teacher Training (ITT) mentors.",
+    columns: {
+        TRN: {
+            description: "Teacher Reference Number (TRN) of the mentor - a teacher - who this provider received funding to train as an ITT and/or ECF mentor",
+            bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+        },
+        provider_name: "Name of the organisation (provider) which received direct funding from DfE to train this teacher to be an ITT and/or ECF mentor.\nFull name, e.g. Ambition Institute.\nNot necessarily the only organisation involved in training this mentor.",
+        first_started_funded_ecf_mentor_training_on: "Date when this mentor first started ECF mentor training for which this provider which was funded directly by DfE",
+        first_completed_funded_ecf_mentor_training_with_this_lead_provider_on: "Date when this ECF mentor first completed ECF mentor training with this provider, if this provider was funded directly by DfE for the period of training which immediately resulted in completion",
+        last_took_part_in_funded_ecf_mentor_training_with_this_lead_provider_on: "Date when this ECF mentor most recently took part in ECF mentor training with this provider for any period of training funded directly by DfE. Does not necessarily indicate that the mentor completed the training.",
+        earliest_itt_mentor_training_funding_claim_submitted_at: "Date of the earliest claim submitted for each mentor for ITT mentor training with with this provider.",
+        AY_first_started_funded_ecf_mentor_training_in: "first_started_funded_ecf_mentor_training_on as an academic year in format 2030-31",
+        AY_earliest_itt_mentor_training_funding_claim_submitted_in: "earliest_itt_mentor_training_funding_claim_submitted_at as an academic year in format 2030-31"
+    }
+}
+
+SELECT
+  COALESCE(ecf_mentor_provider.TRN, itt_mentor_provider.TRN) AS TRN,
+  COALESCE(ecf_mentor_provider.provider_name, itt_mentor_provider.provider_name) AS provider_name,
+  MIN(first_started_funded_mentor_training_on) AS first_started_funded_ecf_mentor_training_on,
+  MIN(first_completed_funded_mentor_training_with_this_lead_provider_on) AS first_completed_funded_ecf_mentor_training_with_this_lead_provider_on,
+  MAX(last_took_part_in_funded_mentor_training_with_this_lead_provider_on) AS last_took_part_in_funded_ecf_mentor_training_with_this_lead_provider_on,
+  MIN(earliest_claim_submitted_at) AS earliest_itt_mentor_training_funding_claim_submitted_at,
+  CASE
+    WHEN LOGICAL_OR(itt_mentor_provider.TRN IS NOT NULL) AND LOGICAL_AND(ecf_mentor_provider.TRN IS NULL) THEN "Funded for ITT mentor training only"
+    WHEN LOGICAL_AND(itt_mentor_provider.TRN IS NULL) AND LOGICAL_OR(ecf_mentor_provider.TRN IS NOT NULL) THEN "Funded for ECF mentor training only"
+    WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) < MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) THEN
+      CASE
+        WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) >= MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on) THEN "First funded for ITT mentor training after completing ECF mentor training with this provider"
+        WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) < MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on) THEN "First funded for ITT mentor training before completing ECF mentor training with this provider"
+        WHEN LOGICAL_AND(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on IS NULL) THEN "First funded for ITT mentor training after starting but not (yet) completing ECF mentor training"
+        ELSE "Error in query logic - please report. First funded for ITT mentor training after ECF mentor training"
+      END
+    WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) > MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) THEN "First funded for ECF mentor training after ITT mentor training"
+    WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) = MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) THEN "First funded for ECF and ITT mentor training on same date"
+    ELSE "Error in query logic - please report"
+END
+  AS mentor_type,
+  CONCAT(
+    EXTRACT(YEAR FROM(MIN(ecf_mentor_provider.first_started_funded_mentor_training_on))) - 
+    IF(EXTRACT(MONTH FROM MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)) < 9, 1, 0),
+    '-',
+    RIGHT(
+        CAST(
+        EXTRACT(YEAR FROM(MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)))
+            - IF(EXTRACT(MONTH FROM MIN(ecf_mentor_provider.first_started_funded_mentor_training_on)) < 9, 1, 0) + 1 AS STRING
+        ), 2
+    )
+    ) AS AY_first_started_funded_ecf_mentor_training_in,
+  CONCAT(
+    EXTRACT(YEAR FROM(MIN(earliest_claim_submitted_at))) - 
+    IF(EXTRACT(MONTH FROM MIN(earliest_claim_submitted_at)) < 9, 1, 0),
+    '-',
+    RIGHT(
+        CAST(
+        EXTRACT(YEAR FROM(MIN(earliest_claim_submitted_at)))
+            - IF(EXTRACT(MONTH FROM MIN(earliest_claim_submitted_at)) < 9, 1, 0) + 1 AS STRING
+        ), 2
+    )
+    ) AS AY_earliest_itt_mentor_training_funding_claim_submitted_in
+FROM
+  ${ref("ecf_mentors_and_providers")} AS ecf_mentor_provider
+FULL JOIN
+  ${ref("itt_mentor_claims")} AS itt_mentor_provider
+ON
+  ecf_mentor_provider.TRN = itt_mentor_provider.TRN
+  AND ecf_mentor_provider.provider_name = itt_mentor_provider.provider_name
+GROUP BY
+  TRN,
+  provider_name

--- a/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
+++ b/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
@@ -48,9 +48,9 @@ SELECT
         THEN "Funded for ECF mentor training only"
     WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) < MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) THEN
       CASE
-        WHEN MIN(itt_mentor_provider.earliest_claim_submitted_at) >= MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on)
+        WHEN MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) >= MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on)
             THEN "First funded for ITT mentor training after completing ECF mentor training with this provider"
-        WHEN MIN(itt_mentor_provider.earliest_claim_submitted_at) < MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on)
+        WHEN MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) < MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on)
             THEN "First funded for ITT mentor training between starting and completing ECF mentor training with this provider"
         WHEN LOGICAL_AND(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on IS NULL)
             THEN "First funded for ITT mentor training after starting but not (yet) completing ECF mentor training"

--- a/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
+++ b/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
@@ -17,7 +17,8 @@ config {
         last_took_part_in_funded_ecf_mentor_training_with_this_lead_provider_on: "Date when this ECF mentor most recently took part in ECF mentor training with this provider for any period of training funded directly by DfE. Does not necessarily indicate that the mentor completed the training.",
         earliest_itt_mentor_training_funding_claim_submitted_at: "Date of the earliest claim submitted for each mentor for ITT mentor training with with this provider.",
         AY_first_started_funded_ecf_mentor_training_in: "first_started_funded_ecf_mentor_training_on as an academic year in format 2030-31",
-        AY_earliest_itt_mentor_training_funding_claim_submitted_in: "earliest_itt_mentor_training_funding_claim_submitted_at as an academic year in format 2030-31"
+        AY_earliest_itt_mentor_training_funding_claim_submitted_in: "earliest_itt_mentor_training_funding_claim_submitted_at as an academic year in format 2030-31",
+        mentor_type: "Plain text summary of the order in which the mentor was funded for ECF and/or ITT mentor training (if they were)"
     }
 }
 

--- a/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
+++ b/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
@@ -21,6 +21,18 @@ config {
     }
 }
 
+/* Permissions setup:
+This definition assumes that an Owner of the Becoming a Teacher (BaT) GCP project has done the following:
+1. In the Becoming a Teacher (BaT) GCP project, create an analytics hub.
+2. Share the BaT itt_mentor_analytics_hub dataset by creating a Listing containing the itt_mentor_claims in this analytics hub.
+3. Give a user with access to the CPD GCP project Analytics Hub Subscriber access to this Listing.
+4. Give the CPD Dataform service account the Fine-Grained Reader role *only* on the BaT BigQuery project (from the project level IAMs screen)
+
+It then assumes that an Owner of the CPD GCP project has done the following:
+1. Subscribe to the Listing shared with them from the BaT analytics hub
+2. Ensure that the itt_mentor_claims declaration in this Dataform repo is pointing to the dataset they imported the Listing to
+*/
+
 SELECT
   COALESCE(ecf_mentor_provider.TRN, itt_mentor_provider.TRN) AS TRN,
   COALESCE(ecf_mentor_provider.provider_name, itt_mentor_provider.provider_name) AS provider_name,

--- a/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
+++ b/definitions/marts/itt_mentor_marts/mentors_and_providers_itt_ecf_combined.sqlx
@@ -41,17 +41,24 @@ SELECT
   MAX(last_took_part_in_funded_mentor_training_with_this_lead_provider_on) AS last_took_part_in_funded_ecf_mentor_training_with_this_lead_provider_on,
   MIN(earliest_claim_submitted_at) AS earliest_itt_mentor_training_funding_claim_submitted_at,
   CASE
-    WHEN LOGICAL_OR(itt_mentor_provider.TRN IS NOT NULL) AND LOGICAL_AND(ecf_mentor_provider.TRN IS NULL) THEN "Funded for ITT mentor training only"
-    WHEN LOGICAL_AND(itt_mentor_provider.TRN IS NULL) AND LOGICAL_OR(ecf_mentor_provider.TRN IS NOT NULL) THEN "Funded for ECF mentor training only"
+    WHEN LOGICAL_OR(itt_mentor_provider.TRN IS NOT NULL) AND LOGICAL_AND(ecf_mentor_provider.TRN IS NULL)
+        THEN "Funded for ITT mentor training only"
+    WHEN LOGICAL_AND(itt_mentor_provider.TRN IS NULL) AND LOGICAL_OR(ecf_mentor_provider.TRN IS NOT NULL)
+        THEN "Funded for ECF mentor training only"
     WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) < MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) THEN
       CASE
-        WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) >= MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on) THEN "First funded for ITT mentor training after completing ECF mentor training with this provider"
-        WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) < MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on) THEN "First funded for ITT mentor training before completing ECF mentor training with this provider"
-        WHEN LOGICAL_AND(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on IS NULL) THEN "First funded for ITT mentor training after starting but not (yet) completing ECF mentor training"
+        WHEN MIN(itt_mentor_provider.earliest_claim_submitted_at) >= MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on)
+            THEN "First funded for ITT mentor training after completing ECF mentor training with this provider"
+        WHEN MIN(itt_mentor_provider.earliest_claim_submitted_at) < MIN(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on)
+            THEN "First funded for ITT mentor training between starting and completing ECF mentor training with this provider"
+        WHEN LOGICAL_AND(ecf_mentor_provider.first_completed_funded_mentor_training_with_this_lead_provider_on IS NULL)
+            THEN "First funded for ITT mentor training after starting but not (yet) completing ECF mentor training"
         ELSE "Error in query logic - please report. First funded for ITT mentor training after ECF mentor training"
       END
-    WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) > MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) THEN "First funded for ECF mentor training after ITT mentor training"
-    WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) = MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at)) THEN "First funded for ECF and ITT mentor training on same date"
+    WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) > MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at))
+        THEN "First funded for ECF mentor training after ITT mentor training"
+    WHEN MIN(ecf_mentor_provider.first_started_funded_mentor_training_on) = MIN(DATE(itt_mentor_provider.earliest_claim_submitted_at))
+        THEN "First funded for ECF and ITT mentor training on same date"
     ELSE "Error in query logic - please report"
 END
   AS mentor_type,


### PR DESCRIPTION
Also:
- Declare the source data imported from the ITT mentor service via the BaT BQ project
- Reuse existing development datasets for the ecf_mentors_and_providers table instead of spinning up datasets called itt_mentor_SL_dev specially
- Add assertion to check that provider_name is in the agreed format (if it isn't then there's a risk that the join stops working)
- Ensure ECF mentor TRN is a string so it matches across the join with the ITT mentor TRN