### PR TITLE
Converting TRN to string in pipeline

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -1120,7 +1120,7 @@ dfeAnalyticsDataform({
                 description: ""
             }, {
                 keyName: "trn",
-                dataType: "integer",
+                dataType: "string",
                 description: ""
             }, {
                 keyName: "user_id",

--- a/definitions/dfe_analytics_dataform_npq.js
+++ b/definitions/dfe_analytics_dataform_npq.js
@@ -773,7 +773,7 @@ dfeAnalyticsDataform({
             description: "The GUID for the user. This can be used to link to ECF Teacher Profiles on user_id and will be used by Lead providers to call APIs on specific users."
         }, {
             keyName: "trn",
-            dataType: "integer",
+            dataType: "string",
             description: ""
         }, {
             keyName: "trn_verified",

--- a/definitions/marts/looker_studio_marts/npq/ls_npq_tsf_application_detail.sqlx
+++ b/definitions/marts/looker_studio_marts/npq/ls_npq_tsf_application_detail.sqlx
@@ -66,7 +66,7 @@ WITH
     application_trn,
     -- Manually amend the trn_verfified for TRN 1137983 as participant profile has been deleted in service but application was not re-assigned. Only known case in the data. 
     CASE
-      WHEN application_trn = '1137983' THEN 1137983
+      WHEN application_trn = '1137983' THEN '1137983'
       ELSE trn_verified
     END AS trn_verified,
     cohort,


### PR DESCRIPTION
We need TRNs to be strings for the hidden PII functionality of service accounts to work properly. I've changed the type at the source to enable downstream trns to be only strings.