### PR TITLE
Basic web analytics V1

### DIFF
--- a/definitions/dfe_analytics_dataform.js
+++ b/definitions/dfe_analytics_dataform.js
@@ -8,6 +8,8 @@ dfeAnalyticsDataform({
     expirationDays: false,
     urlRegex: 'manage-training-for-early-career-teachers.education.gov.uk',
     hiddenPolicyTagLocation: "projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339",
+    enableSessionTables: false,
+    enableSessionDetailsTable: true,
     customEventSchema: [{
         eventType: "persist_api_request",
         description: "Custom event set-up for API Requests as of 04/11/2024",

--- a/definitions/dfe_analytics_dataform_ecf2.js
+++ b/definitions/dfe_analytics_dataform_ecf2.js
@@ -8,6 +8,8 @@ dfeAnalyticsDataform({
     expirationDays: false,
     urlRegex: 'manage-training-for-early-career-teachers.education.gov.uk',
     hiddenPolicyTagLocation: "projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339",
+    enableSessionTables: false,
+    enableSessionDetailsTable: true,
     customEventSchema: [],
     dataSchema: [{
             entityTableName: "appropriate_bodies",

--- a/definitions/dfe_analytics_dataform_npq.js
+++ b/definitions/dfe_analytics_dataform_npq.js
@@ -8,6 +8,8 @@ dfeAnalyticsDataform({
     expirationDays: false,
     urlRegex: 'manage-training-for-early-career-teachers.education.gov.uk',
     hiddenPolicyTagLocation: "projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339",
+    enableSessionTables: false,
+    enableSessionDetailsTable: true,
     dataSchema: [{
         entityTableName: "applications",
         description: "",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_page_dates.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_page_dates.sqlx
@@ -1,0 +1,44 @@
+config {
+    type: "incremental",
+    assertions: {
+        uniqueKey: ["page_path", "date"]
+    },
+    bigquery: {
+        partitionBy: "date"
+    },
+    description: "Cube containing aggregable metrics about a particular page_path on a date. Does not include data for the current date because this data is incomplete.",
+    columns: {
+        page_path: "Path of a page on an ECF service, excluding the domain and query string.",
+        date: "Date for which metrics have been calculated",
+        number_of_views: "Total number of non-unique views of page_path which occurred on date.",
+        number_of_exits: "Total number of times a view of page_path on date was the last pageview within a session in session_details.",
+        number_of_bounces: "Total number of times a view of page_path on date was both the first and the last pageview within a session in session_details.",
+        number_of_unique_views: "Total number of unique authenticated users who viewed page_path on date.",
+        total_time_on_page: "Total time spent 'on' page_path on date, where time 'on' page is defined as the length of time between viewing the page and viewing the next page within the same session (if a next pageview happened within the same session)"
+    }
+}
+
+pre_operations {
+  DECLARE date_checkpoint DEFAULT (
+    ${when(incremental(),
+    `SELECT MAX(date) FROM ${self()}`,
+    `SELECT DATE("2000-01-01")`)}
+  )
+}
+
+SELECT
+  page_path,
+  DATE(page_entry_time) AS date,
+  COUNT(*) AS number_of_views,
+  COUNTIF(next_step = "End of session") AS number_of_exits,
+  COUNTIF(next_step = "End of session" AND pageview_number_in_session = 1) AS number_of_bounces,
+  COUNT(DISTINCT user_id) AS number_of_unique_views,
+  SUM(time_on_page) AS total_time_on_page
+FROM
+  ${ref("ls_ecf_pageview_next_steps")}
+WHERE
+  DATE(page_entry_time) < CURRENT_DATE
+  AND DATE(page_entry_time) > date_checkpoint
+GROUP BY
+  page_path,
+  DATE(page_entry_time)

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_page_dates.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_page_dates.sqlx
@@ -14,7 +14,7 @@ config {
         number_of_exits: "Total number of times a view of page_path on date was the last pageview within a session in session_details.",
         number_of_bounces: "Total number of times a view of page_path on date was both the first and the last pageview within a session in session_details.",
         number_of_unique_views: "Total number of unique authenticated users who viewed page_path on date.",
-        total_time_on_page: "Total time spent 'on' page_path on date, where time 'on' page is defined as the length of time between viewing the page and viewing the next page within the same session (if a next pageview happened within the same session)"
+        total_time_on_page: "Total number of seconds spent 'on' page_path on date, where time 'on' page is defined as the length of time between viewing the page and viewing the next page within the same session (if a next pageview happened within the same session)"
     }
 }
 

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
@@ -17,7 +17,7 @@ config {
         next_step: "Path of the next page that was viewed on this service, if it was. If it wasn't, contains the string 'End of session'.",
         pageview_number_in_session: "Number indicating that this pageview was the Nth pageview within this session.",
         previous_page_domain: "Domain of the previous page that was viewed, if it was and if this is available. May be an external site.",
-        time_on_page: "Duration between page_entry_time and the page_entry_time of the next pageview if it exists. NULL otherwise.",
+        time_on_page: "Number of seconds between page_entry_time and the page_entry_time of the next pageview if it exists. NULL otherwise.",
         admin_session: "TRUE if this user was an internal DfE admin user, deduced from whether they viewed any page path containing 'admin' at any point in the session.",
         session_utm_source: "Value of the utm_source UTM parameter for the first pageview in the session, if it was set. Useful to categorise traffic for marketing purposes.",
         session_utm_medium: "Value of the utm_medium UTM parameter for the first pageview in the session, if it was set. Useful to categorise traffic for marketing purposes.",
@@ -52,7 +52,7 @@ FROM
       IFNULL(LEAD(page) OVER pageviews_in_order, "End of session") AS next_step,
       ROW_NUMBER() OVER pageviews_in_order AS pageview_number_in_session,
       previous_page_domain,
-      MAKE_INTERVAL(second => duration) AS time_on_page,
+      duration AS time_on_page,
       LOGICAL_OR(CONTAINS_SUBSTR(page, "admin")) OVER pageviews_in_order AS admin_session
     FROM
       UNNEST(pages_visited_details)

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
@@ -1,0 +1,64 @@
+config {
+    type: "incremental",
+    assertions: {
+        uniqueKey: ["session_id", "pageview_number_in_session", "user_id"]
+    },
+    bigquery: {
+        partitionBy: "DATE(session_start_timestamp)"
+    },
+    description: "Pageviews that occurred on an ECF service, along with details of previous and next steps users took within their session. Sessions defined Google Analytics style from the dfe-analytics-dataform session_details table. Intended to support a funnel analysis dashboard.",
+    columns: {
+        session_id: "UID of this session",
+        user_id: "ID of the user logged in at some point during this session - if they were. Traffic from separate user_ids is always separated into separate sessions.",
+        session_start_timestamp: "Time at which the session began",
+        page_path: "Path of the page that was viewed, excluding domain and query string.",
+        previous_page_path: "Path of the previous page that was viewed on this service, if it was.",
+        page_entry_time: "Time at which this pageview happened.",
+        next_step: "Path of the next page that was viewed on this service, if it was. If it wasn't, contains the string 'End of session'.",
+        pageview_number_in_session: "Number indicating that this pageview was the Nth pageview within this session.",
+        previous_page_domain: "Domain of the previous page that was viewed, if it was and if this is available. May be an external site.",
+        time_on_page: "Duration between page_entry_time and the page_entry_time of the next pageview if it exists. NULL otherwise.",
+        admin_session: "TRUE if this user was an internal DfE admin user, deduced from whether they viewed any page path containing 'admin' at any point in the session.",
+        session_utm_source: "Value of the utm_source UTM parameter for the first pageview in the session, if it was set. Useful to categorise traffic for marketing purposes.",
+        session_utm_medium: "Value of the utm_medium UTM parameter for the first pageview in the session, if it was set. Useful to categorise traffic for marketing purposes.",
+        session_utm_campaign: "Value of the utm_campaign UTM parameter for the first pageview in the session, if it was set. Useful to categorise traffic for marketing purposes."
+    }
+}
+
+pre_operations {
+  DECLARE session_timestamp_checkpoint DEFAULT (
+    ${when(incremental(),
+    `SELECT MAX(session_start_timestamp) FROM ${self()}`,
+    `SELECT TIMESTAMP("2000-01-01")`)}
+  )
+}
+
+SELECT
+  session_id,
+  user_id,
+  session_start_timestamp,
+  pageview.*,
+  utm_source AS session_utm_source,
+  utm_medium AS session_utm_medium,
+  utm_campaign AS session_utm_campaign
+FROM
+  ${ref("session_details_cpd")},
+  UNNEST(ARRAY(
+    SELECT
+      AS STRUCT
+      page AS page_path,
+      previous_page AS previous_page_path,
+      page_entry_time,
+      IFNULL(LEAD(page) OVER pageviews_in_order, "End of session") AS next_step,
+      ROW_NUMBER() OVER pageviews_in_order AS pageview_number_in_session,
+      previous_page_domain,
+      MAKE_INTERVAL(second => duration) AS time_on_page,
+      LOGICAL_OR(CONTAINS_SUBSTR(page, "admin")) OVER pageviews_in_order AS admin_session
+    FROM
+      UNNEST(pages_visited_details)
+    WINDOW
+      pageviews_in_order AS (
+      ORDER BY
+        page_entry_time ASC))) AS pageview
+WHERE
+  session_start_timestamp > session_timestamp_checkpoint

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
@@ -12,11 +12,12 @@ config {
         user_id: "ID of the user logged in at some point during this session - if they were. Traffic from separate user_ids is always separated into separate sessions.",
         session_start_timestamp: "Time at which the session began",
         page_path: "Path of the page that was viewed, excluding domain and query string.",
-        previous_page_path: "Path of the previous page that was viewed on this service, if it was.",
+        referer_path: "Path of the previous page that was viewed, if it was. May be an external site or an internal pageview from a previous session. Not the same as previous_step.",
+        referer_domain: "Domain of the previous page that was viewed, if it was and if this is available. May be an external site or an internal pageview from a previous session.",
         page_entry_time: "Time at which this pageview happened.",
-        next_step: "Path of the next page that was viewed on this service, if it was. If it wasn't, contains the string 'End of session'.",
+        next_step: "Path of the next page that was viewed on this service within this session, if it was. If it wasn't, contains the string 'End of session'.",
+        previous_step: "Path of the previous page that was viewed on this service *within this session*, if it was. If it wasn't, contains the string 'End of session'. Not the same as referer_path.",
         pageview_number_in_session: "Number indicating that this pageview was the Nth pageview within this session.",
-        previous_page_domain: "Domain of the previous page that was viewed, if it was and if this is available. May be an external site.",
         time_on_page: "Number of seconds between page_entry_time and the page_entry_time of the next pageview if it exists. NULL otherwise.",
         admin_session: "TRUE if this user was an internal DfE admin user, deduced from whether they viewed any page path containing 'admin' at any point in the session.",
         session_utm_source: "Value of the utm_source UTM parameter for the first pageview in the session, if it was set. Useful to categorise traffic for marketing purposes.",
@@ -47,13 +48,14 @@ FROM
     SELECT
       AS STRUCT
       page AS page_path,
-      previous_page AS previous_page_path,
+      previous_page AS referer_path,
       page_entry_time,
       IFNULL(LEAD(page) OVER pageviews_in_order, "End of session") AS next_step,
+      IFNULL(LAG(page) OVER pageviews_in_order, "Start of session") AS previous_step,
       ROW_NUMBER() OVER pageviews_in_order AS pageview_number_in_session,
-      previous_page_domain,
+      previous_page_domain AS referer_domain,
       duration AS time_on_page,
-      LOGICAL_OR(CONTAINS_SUBSTR(page, "admin")) OVER pageviews_in_order AS admin_session
+      LOGICAL_OR(CONTAINS_SUBSTR(page, "/admin")) OVER pageviews_in_order AS admin_session
     FROM
       UNNEST(pages_visited_details)
     WINDOW

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_pageview_next_steps.sqlx
@@ -47,11 +47,11 @@ FROM
   UNNEST(ARRAY(
     SELECT
       AS STRUCT
-      page AS page_path,
-      previous_page AS referer_path,
+      REGEXP_REPLACE(page, "([a-zA-Z0-9-]*[0-9]+[a-zA-Z0-9-]*)", "[grouped]") AS page_path,
+      REGEXP_REPLACE(previous_page, "([a-zA-Z0-9-]*[0-9]+[a-zA-Z0-9-]*)", "[grouped]") AS referer_path,
       page_entry_time,
-      IFNULL(LEAD(page) OVER pageviews_in_order, "End of session") AS next_step,
-      IFNULL(LAG(page) OVER pageviews_in_order, "Start of session") AS previous_step,
+      IFNULL(LEAD(REGEXP_REPLACE(page, "([a-zA-Z0-9-]*[0-9]+[a-zA-Z0-9-]*)", "[grouped]")) OVER pageviews_in_order, "End of session") AS next_step,
+      IFNULL(LAG(REGEXP_REPLACE(page, "([a-zA-Z0-9-]*[0-9]+[a-zA-Z0-9-]*)", "[grouped]")) OVER pageviews_in_order, "Start of session") AS previous_step,
       ROW_NUMBER() OVER pageviews_in_order AS pageview_number_in_session,
       previous_page_domain AS referer_domain,
       duration AS time_on_page,


### PR DESCRIPTION
Initial version of tables to support MVP of basic web analytics. This should include everything in the design in the Trello card except for user agent-derived fields. Crucially this means we won't be able to exclude bot traffic, nor will we be able to break funnels down by mobile v desktop. I'm speaking to Arjun about whether we can include these in the dfe-analytics-dataform session_details table; if not we can work them out ourselves.

Also disables old style dfe-analytics-dataform sessions and funnel analysis tables to save cost. We should delete these after merging.