### PR TITLE
Testing API Monitoring Mart + Grant Funding Mentor Mart Update

### DIFF
--- a/definitions/declarations/ecf_events_sandbox.sqlx
+++ b/definitions/declarations/ecf_events_sandbox.sqlx
@@ -1,0 +1,5 @@
+config {
+    type: "declaration",
+    schema: "ecf_events_sandbox",
+    name: "events"
+}

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_mentor_backfill_grant_funding.sqlx
@@ -108,7 +108,7 @@ WITH declarations AS (
     AND
     participant_course = 'Mentor'
     AND
-    dec.declaration_date >= '2023-09-01' AND dec.declaration_date <= '2024-08-31'
+    dec.declaration_date >= '2024-09-01' AND dec.declaration_date <= '2025-08-31'
   QUALIFY
     ROW_NUMBER() OVER(PARTITION BY dec.declaration_id ORDER BY COALESCE(ind.start_date, ind2.start_date) DESC, COALESCE(ind.created_at, ind2.created_at) DESC) = 1
 ),
@@ -122,7 +122,7 @@ ects AS (
   WHERE
     participant_type LIKE '%ECT'
     AND
-    completion_date IS NULL OR completion_date > '2023-08-31'
+    completion_date IS NULL OR completion_date > '2024-08-31'
   GROUP BY
     school_urn
   ORDER BY 

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
@@ -60,14 +60,14 @@ WITH
     request_uuid,DATA)
 SELECT
   api_events.*,
-  CASE
-    WHEN api_events.user_id = '98600c9f-1ea4-43e5-b217-4cda78ed1091' THEN 'Ambition'
-    WHEN api_events.user_id = 'd83fde1f-d763-4498-baf0-498d223003f2' THEN 'NiOT'
-    WHEN api_events.user_id = 'ad88a832-a4e9-420e-8d25-b7f1e33fd73e' THEN 'Capita'
-    WHEN api_events.user_id = '2af6d829-a540-4b7a-bf48-9a0d21bc036f' THEN 'EDT'
-    WHEN api_events.user_id = 'b15bbd82-7e44-4abb-8761-df1b88370394' THEN 'Teach First'
-    WHEN api_events.user_id = 'ccf2e1f5-a876-43a4-9820-c8e93088ebd1' THEN 'BPN'
-    WHEN api_events.user_id = '8e433f5c-8c1a-462b-a2b6-735738a6a574' THEN 'UCL'
+  CASE api_events.user_id
+    WHEN '98600c9f-1ea4-43e5-b217-4cda78ed1091' THEN 'Ambition'
+    WHEN 'd83fde1f-d763-4498-baf0-498d223003f2' THEN 'NiOT'
+    WHEN 'ad88a832-a4e9-420e-8d25-b7f1e33fd73e' THEN 'Capita'
+    WHEN '2af6d829-a540-4b7a-bf48-9a0d21bc036f' THEN 'EDT'
+    WHEN 'b15bbd82-7e44-4abb-8761-df1b88370394' THEN 'Teach First'
+    WHEN 'ccf2e1f5-a876-43a4-9820-c8e93088ebd1' THEN 'BPN'
+    WHEN '8e433f5c-8c1a-462b-a2b6-735738a6a574' THEN 'UCL'
     ELSE api_events.user_id
 END
   AS lp_name,

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
@@ -7,10 +7,10 @@ config {
         partitionBy: "DATE(occurred_at)",
         clusterBy: ["request_method", "user_id", "response_status"]
     },
-    description: "This mart produces a table outlining all API calls that have been made by Lead Providers in the sandbox testing environment. It excludes internal users (identified as those with a NULL user_id) to ensure the focus is more on LP usage. The table outlines the response statuses of those calls to help the LPDOB team identify Providers who are causing a large number of errors. The final output feeds into the CPD- API Monitoring dashboard.",
+    description: "This mart produces a table outlining all Testing API calls that have been made by Lead Providers in the sandbox testing environment. It excludes internal users (identified as those with a NULL user_id) to ensure the focus is more on LP usage. The table outlines the response statuses of those calls to help the LPDOB and Digital Engagement team identify how the LPs are engaging with the new testing API. The final output feeds into the Testing API tabs of the CPD- API Monitoring dashboard.",
     columns: {
         occurred_at: "Timestamp of when the API call was made.",
-        user_id: "User ID of the Lead Provider making the API call. NULL user_ids are excluded as they are internal users.",
+        user_id: "User ID of the Lead Provider making the API call. NULL user_ids are excluded as they are internal users. These user_ids differ from the user_ids available for LPs in the Production environment and cannot be mapped onto the cpd_lead_provider_id as user_ids for within the Production environment can",
         request_uuid: "ID of individual request.",
         request_method: "Method for calling the API. Can be GET, POST, or PUT.",
         request_path: "The endpoint that is being accessed.",

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
@@ -7,7 +7,7 @@ config {
         partitionBy: "DATE(occurred_at)",
         clusterBy: ["request_method", "user_id", "response_status"]
     },
-    description: "This mart produces a table outlining all API calls that have been made by Lead Providers. It excludes internal users (identified as those with a NULL user_id) to ensure the focus is more on LP usage. The table outlines the response statuses of those calls to help the LPDOB team identify Providers who are causing a large number of errors. The final output feeds into the CPD- API Monitoring dashboard.",
+    description: "This mart produces a table outlining all API calls that have been made by Lead Providers in the sandbox testing environment. It excludes internal users (identified as those with a NULL user_id) to ensure the focus is more on LP usage. The table outlines the response statuses of those calls to help the LPDOB team identify Providers who are causing a large number of errors. The final output feeds into the CPD- API Monitoring dashboard.",
     columns: {
         occurred_at: "Timestamp of when the API call was made.",
         user_id: "User ID of the Lead Provider making the API call. NULL user_ids are excluded as they are internal users.",
@@ -20,13 +20,13 @@ config {
         request_body: "Details the call made by the Lead Provider.",
         response_body: "Details the API response. Usually populated if there are any errors with the API call being made.",
         hidden_DATA: {
-          columns: {
-            key: "Name of a field containing sensitive data included in this API request custom event from dfe-analytics",
-            value: {
-              description: "Contents of this field",
-              bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+            columns: {
+                key: "Name of a field containing sensitive data included in this API request custom event from dfe-analytics",
+                value: {
+                    description: "Contents of this field",
+                    bigqueryPolicyTags: ["projects/ecf-bq/locations/europe-west2/taxonomies/6302091323314055162/policyTags/301313311867345339"]
+                }
             }
-          }
         }
     }
 }
@@ -45,7 +45,7 @@ WITH
       request_user_agent,
       response_content_type)
   FROM
-    ${ref("ecf_events_production", "events")}
+    ${ref("ecf_events_sandbox", "events")}
   WHERE
     event_type = 'web_request'
     AND user_id IS NOT NULL
@@ -55,8 +55,7 @@ WITH
       '3b0872b43cd564d2133dbbff6fa1a4cf',
       'ad6a40fda446b96f3212cdb57d2e98e6',
       'c1fdb72bd593d9eda54f8e95e9724884',
-      '8bee2f527391c8891cbaee1775670f46')
-),
+      '8bee2f527391c8891cbaee1775670f46') ),
   request_response_fields AS (
   SELECT
     eep.request_uuid,
@@ -67,7 +66,7 @@ WITH
     IF
       (struct_field.key = "response_body", this_value, NULL), ', ') AS response_body
   FROM
-    ${ref("ecf_events_production", "events")} AS eep,
+    ${ref("ecf_events_sandbox","events")} AS eep,
     UNNEST(eep.DATA) AS struct_field,
     UNNEST(struct_field.value) AS this_value
   WHERE
@@ -77,19 +76,14 @@ WITH
 SELECT
   dc.*,
   CASE
-    WHEN dc.user_id = '22727fdc-816a-4a3c-9675-030e724bbf89' THEN 'Ambition'
-    WHEN dc.user_id = '24cdd065-4eb9-455a-8107-2ffb125f399f' THEN 'TDT'
-    WHEN dc.user_id = '3b3fab47-231f-43fe-bcec-98960a60acae' THEN 'CoE'
-    WHEN dc.user_id = '3dad03a0-08a5-4bf3-a9c9-082b7f4e78d4' THEN 'School-Led Network'
-    WHEN dc.user_id = '51ff9a95-3f48-4117-8466-4cd5b91fcd5c' THEN 'NiOT'
-    WHEN dc.user_id = '522a0342-e8d2-46fc-aaa3-716fa6e35751' THEN 'LLSE'
-    WHEN dc.user_id = '9ad41410-677f-4da3-86a1-cda62b42e176' THEN 'Capita'
-    WHEN dc.user_id = 'af89cf02-bbe0-423b-b2f6-bb2dbb97d141' THEN 'EDT'
-    WHEN dc.user_id = 'bd152c5a-5ef4-4584-9c63-c32877dbba07' THEN 'Teach First'
-    WHEN dc.user_id = 'dfad2a9c-527d-4d71-ae9a-492ab307e6c3' THEN 'BPN'
-    WHEN dc.user_id = 'fb9c56b2-252b-41fe-b6b2-ebf208999df9' THEN 'UCL'
-  ELSE
-  dc.user_id
+    WHEN dc.user_id = '98600c9f-1ea4-43e5-b217-4cda78ed1091' THEN 'Ambition'
+    WHEN dc.user_id = 'd83fde1f-d763-4498-baf0-498d223003f2' THEN 'NiOT'
+    WHEN dc.user_id = 'ad88a832-a4e9-420e-8d25-b7f1e33fd73e' THEN 'Capita'
+    WHEN dc.user_id = '2af6d829-a540-4b7a-bf48-9a0d21bc036f' THEN 'EDT'
+    WHEN dc.user_id = 'b15bbd82-7e44-4abb-8761-df1b88370394' THEN 'Teach First'
+    WHEN dc.user_id = 'ccf2e1f5-a876-43a4-9820-c8e93088ebd1' THEN 'BPN'
+    WHEN dc.user_id = '8e433f5c-8c1a-462b-a2b6-735738a6a574' THEN 'UCL'
+    ELSE dc.user_id
 END
   AS lp_name,
   rrf.request_body,

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
@@ -32,64 +32,49 @@ config {
 }
 
 WITH
-  data_cut AS (
+  api_events AS (
   SELECT
-    * EXCEPT (anonymised_user_agent_and_ip,
-      DATA,
-      entity_table_name,
-      environment,
-      event_tags,
-      event_type,
-      namespace,
-      request_referer,
-      request_user_agent,
-      response_content_type)
+    occurred_at,
+    user_id,
+    request_uuid,
+    request_method,
+    request_path,
+    request_query,
+    response_status
   FROM
     ${ref("ecf_events_sandbox", "events")}
   WHERE
     event_type = 'web_request'
     AND user_id IS NOT NULL
-    AND request_path LIKE '/api/v%'
-    AND request_uuid NOT IN ('edc376f322a4dc273b62997804695fb5',
-      '13f9f767fabfcb2cafc16f366b72660e',
-      '3b0872b43cd564d2133dbbff6fa1a4cf',
-      'ad6a40fda446b96f3212cdb57d2e98e6',
-      'c1fdb72bd593d9eda54f8e95e9724884',
-      '8bee2f527391c8891cbaee1775670f46') ),
+    AND request_path LIKE '/api/v%'),
   request_response_fields AS (
   SELECT
     eep.request_uuid,
-    STRING_AGG(DISTINCT
-    IF
-      (struct_field.key = "request_body", this_value, NULL), ', ') AS request_body,
-    STRING_AGG(DISTINCT
-    IF
-      (struct_field.key = "response_body", this_value, NULL), ', ') AS response_body
+    ${data_functions.eventDataExtract('DATA', 'request_body', dynamic = false, dataType = 'string', isArray = false)} AS request_body,
+    ${data_functions.eventDataExtract('DATA', 'response_body', dynamic = false, dataType = 'string', isArray = false)} AS response_body
   FROM
-    ${ref("ecf_events_sandbox","events")} AS eep,
-    UNNEST(eep.DATA) AS struct_field,
-    UNNEST(struct_field.value) AS this_value
+    ${ref("ecf_events_sandbox", "events")} AS eep
   WHERE
     entity_table_name = 'api_requests'
   GROUP BY
-    request_uuid)
+    request_uuid,DATA)
 SELECT
-  dc.*,
+  api_events.*,
   CASE
-    WHEN dc.user_id = '98600c9f-1ea4-43e5-b217-4cda78ed1091' THEN 'Ambition'
-    WHEN dc.user_id = 'd83fde1f-d763-4498-baf0-498d223003f2' THEN 'NiOT'
-    WHEN dc.user_id = 'ad88a832-a4e9-420e-8d25-b7f1e33fd73e' THEN 'Capita'
-    WHEN dc.user_id = '2af6d829-a540-4b7a-bf48-9a0d21bc036f' THEN 'EDT'
-    WHEN dc.user_id = 'b15bbd82-7e44-4abb-8761-df1b88370394' THEN 'Teach First'
-    WHEN dc.user_id = 'ccf2e1f5-a876-43a4-9820-c8e93088ebd1' THEN 'BPN'
-    WHEN dc.user_id = '8e433f5c-8c1a-462b-a2b6-735738a6a574' THEN 'UCL'
-    ELSE dc.user_id
+    WHEN api_events.user_id = '98600c9f-1ea4-43e5-b217-4cda78ed1091' THEN 'Ambition'
+    WHEN api_events.user_id = 'd83fde1f-d763-4498-baf0-498d223003f2' THEN 'NiOT'
+    WHEN api_events.user_id = 'ad88a832-a4e9-420e-8d25-b7f1e33fd73e' THEN 'Capita'
+    WHEN api_events.user_id = '2af6d829-a540-4b7a-bf48-9a0d21bc036f' THEN 'EDT'
+    WHEN api_events.user_id = 'b15bbd82-7e44-4abb-8761-df1b88370394' THEN 'Teach First'
+    WHEN api_events.user_id = 'ccf2e1f5-a876-43a4-9820-c8e93088ebd1' THEN 'BPN'
+    WHEN api_events.user_id = '8e433f5c-8c1a-462b-a2b6-735738a6a574' THEN 'UCL'
+    ELSE api_events.user_id
 END
   AS lp_name,
   rrf.request_body,
   rrf.response_body
 FROM
-  data_cut dc
+  api_events
 LEFT JOIN
   request_response_fields rrf
 USING

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_sandbox_api_monitoring.sqlx
@@ -50,8 +50,8 @@ WITH
   request_response_fields AS (
   SELECT
     eep.request_uuid,
-    ${data_functions.eventDataExtract('DATA', 'request_body', dynamic = false, dataType = 'string', isArray = false)} AS request_body,
-    ${data_functions.eventDataExtract('DATA', 'response_body', dynamic = false, dataType = 'string', isArray = false)} AS response_body
+    ${data_functions.eventDataExtract('DATA', 'request_body')} AS request_body,
+    ${data_functions.eventDataExtract('DATA', 'response_body')} AS response_body
   FROM
     ${ref("ecf_events_sandbox", "events")} AS eep
   WHERE


### PR DESCRIPTION
I've replicated the code used for the primary API Monitoring Mart and re-used it for the testing API Sandbox Mart, simply repointing to the Sandbox environment and switching out the Lead Provider IDs that are used in that environment. 

I also updated the Grant Funding Mentor Mart, rolling it over for the 24/25 academic year.