### PR TITLE
Modifying ECF Retention KPI to include post-July 24 Partnerships

### DIFF
--- a/definitions/marts/bigquery_marts/ecf/ecf_retention_kpi_cut_off_date.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_retention_kpi_cut_off_date.sqlx
@@ -131,7 +131,7 @@ partnership_history AS (
         -- AND
     partnership_versions.relationship = FALSE
     AND
-    DATETIME(2024,07,31,23,59,59) BETWEEN DATETIME(partnership_versions.valid_from) AND IFNULL(DATETIME(partnership_versions.valid_to), DATETIME(2050,12,31,00,00,00))
+   IFNULL(DATE(partnership_versions.valid_to), DATE(2050,12,31)) >= DATE('2024-07-31')
   QUALIFY
     ROW_NUMBER() OVER (PARTITION BY partnership_versions.id, IFNULL(DATE(partnership_versions.valid_to), DATE(2050,12,31)) ORDER BY IFNULL(DATETIME(partnership_versions.valid_to), DATETIME(2050,12,31,00,00,00)) DESC, partnership_versions.created_at DESC) = 1
 ),

--- a/definitions/marts/bigquery_marts/ecf/ecf_retention_kpi_mid_point_date.sqlx
+++ b/definitions/marts/bigquery_marts/ecf/ecf_retention_kpi_mid_point_date.sqlx
@@ -126,7 +126,7 @@ partnership_history AS (
     -- AND
     partnership_versions.relationship = FALSE
     AND
-    DATETIME(2024,07,31,23,59,59) BETWEEN DATETIME(partnership_versions.valid_from) AND IFNULL(DATETIME(partnership_versions.valid_to), DATETIME(2050,12,31,00,00,00))
+   IFNULL(DATE(partnership_versions.valid_to), DATE(2050,12,31)) >= DATE('2024-07-31')
   QUALIFY
     ROW_NUMBER() OVER(PARTITION BY partnership_versions.id, IFNULL(DATE(partnership_versions.valid_to), DATE(2050,12,31)) ORDER BY IFNULL(DATETIME(partnership_versions.valid_to), DATETIME(2050,12,31,00,00,00)) DESC, partnership_versions.created_at DESC) = 1
 ),


### PR DESCRIPTION
I believe identified a bug in the code that prevents partnerships created after 31/07/2024 from being included in the final outcome of this mart. I've expanded the definition to allow partnerships after that date to be included. Logic later in the code prevents duplicates and ensures the correct partnership at the correct time is pulled through for a given induction record so there's no risk in this new logic creating duplicates down the line.