### PR TITLE
Removing unique rows assertion of ECF api monitoring

### DIFF
--- a/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
+++ b/definitions/marts/looker_studio_marts/ls_api_monitoring.sqlx
@@ -1,7 +1,6 @@
 config {
     type: "table",
     assertions: {
-        uniqueKey: ["request_uuid"]
     },
     bigquery: {
         partitionBy: "DATE(occurred_at)",


### PR DESCRIPTION
This assertion is causing failures and is incorrect as a request can appear more than once in the api monitoring