### PR TITLE
Fix incorrect ECF mentor training earliest start date

### DIFF
--- a/definitions/marts/itt_mentor_marts/itt_mentor_ecf_mentors_and_providers.sqlx
+++ b/definitions/marts/itt_mentor_marts/itt_mentor_ecf_mentors_and_providers.sqlx
@@ -29,9 +29,10 @@ WITH
   SELECT
     TRN,
     lead_provider_name AS provider_name,
-    CAST(MIN(start_date) AS DATE) AS first_started_funded_mentor_training_on
+    /* Work around bug where in some cases end_date > start_date and indicates that the end_date is actually the start date. The COALESCE ensures that NULL end_dates still produce the start_date and not NULL. */
+    CAST(MIN(COALESCE(LEAST(start_date, end_date), start_date)) AS DATE) AS first_started_funded_mentor_training_on
   FROM
-    ${ref('ecf_inductions_dedupe')}
+    ${ref('ecf_inductions')}
   WHERE
     participant_type LIKE 'ParticipantProfile::Mentor'
   GROUP BY


### PR DESCRIPTION
Previously this was calculated as the earliest start date on any declaration for this TRN and lead provider, according to the ecf_declarations mart. However this mart includes only start_dates taken from the *latest* induction record, which means in cases where there is more than one induction record the earliest induction record is completely ignored.

Now this calculates the earliest start date for a TRN and lead provider directly from the ecf_inductions_dedupe mart instead.