### PR TITLE
Withdrawal Calculation Marts

### DIFF
--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_withdrawal_recommendations.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_withdrawal_recommendations.sqlx
@@ -42,6 +42,7 @@ WITH
     LOGICAL_OR(outcome = 'pass') AS passed_induction
   FROM
     ${ref(`ecf2_teacher_induction_periods`)}
+  WHERE trn is not null
   GROUP BY
     trn)
 

--- a/definitions/marts/looker_studio_marts/ecf/ls_ecf_withdrawal_validations.sqlx
+++ b/definitions/marts/looker_studio_marts/ecf/ls_ecf_withdrawal_validations.sqlx
@@ -6,7 +6,7 @@ config {
     bigquery: {
         clusterBy: ["lead_provider_name"]
     },
-    description: "This mart is used to cross-check withdrawal reasons provided by lead providers with the information we have available for participants on our system. It is used by contract managers to challenge provided withdrawal reasons and recommend the correct withdrawal reason as evidenced by the data we have. It uses subsequent induction records and corresponding induction periods from RIAB to calculate whether participants are still training, what schools and training programmes they've moved to and identify if they've possibly left the profession." ,
+    description: "This mart is used to cross-check withdrawal reasons provided by lead providers with the information we have available for participants on our system. It is used by contract managers to challenge provided withdrawal reasons and recommend the correct withdrawal reason as evidenced by the data we have. It uses subsequent induction records and corresponding induction periods from RIAB to calculate whether participants are still training, what schools and training programmes they've moved to and identify if they've possibly left the profession.",
     columns: {
         user_id: 'This comes from the teacher profile associated with the participant profile.',
         participant_profile_id: 'Participant profiles are automatically generated for ECTs/Mentors when induction tutors register the ECT/Mentor details. Meaning a participant_profile_id (and full participant_profile) should be available for each ECF participant with an induction record. ECF participants have one participant_profile for each type of participation (ECT or Mentor).',
@@ -37,15 +37,15 @@ SELECT
   states.participant_profile_id,
   states.state,
   states.reason,
-  lps.name AS lp_name
+  lead_providers.name AS lp_name
 FROM
   ${ref(`participant_profile_states_latest_ecf1`)} states
 INNER JOIN
-  ${ref(`cpd_lead_providers_latest_ecf1`)} lps
+  ${ref(`cpd_lead_providers_latest_ecf1`)} lead_providers
 ON
-  states.cpd_lead_provider_id = lps.id
+  states.cpd_lead_provider_id = lead_providers.id
 QUALIFY
-  row_number () OVER (PARTITION BY states.participant_profile_id, lps.name ORDER BY states.created_at DESC)=1
+  row_number () OVER (PARTITION BY states.participant_profile_id, lead_providers.name ORDER BY states.created_at DESC)=1
   AND state = 'withdrawn'),
   -- ###This identifies the 'deduped' final record of a participant's induction training at a given lead provider. There should be one record per participant + lead provider combination. It then filters to those records where the participant is recorded as having been withdrawn and is joined on the provided withdrawal reasons above to bring that reason alongside the training record ####
   withdrawn_participants AS (
@@ -59,19 +59,9 @@ SELECT
   lp_dedupe.lead_provider_name,
   lp_dedupe.induction_programme_type,
   --   ## Due to the systems generation of induction records the start date and end date can be mixed, this field recalculates an accurate first start date for this induction record based on the available dates##
-  CASE
-    WHEN lp_dedupe.end_date IS NULL THEN DATE(lp_dedupe.start_date)
-    WHEN lp_dedupe.start_date < lp_dedupe.end_date THEN DATE(lp_dedupe.start_date)
-    ELSE DATE(lp_dedupe.end_date)
-END
-  AS min_start_date,
+  DATE(LEAST(COALESCE(lp_dedupe.end_date,lp_dedupe.start_date),lp_dedupe.start_date)) AS min_start_date,
   --  ## Due to the systems generation of induction records the start date and end date can be mixed, this field recalculates an accurate first end date for this induction record based on the available dates and if the end date gives it a dummy end date in the future##
-  CASE
-    WHEN lp_dedupe.end_date IS NULL THEN DATE(lp_dedupe.end_date)
-    WHEN lp_dedupe.start_date < lp_dedupe.end_date THEN DATE(lp_dedupe.end_date)
-    ELSE DATE(lp_dedupe.start_date)
-END
-  AS max_end_date,
+  DATE(GREATEST(COALESCE(lp_dedupe.end_date,lp_dedupe.start_date),lp_dedupe.start_date)) AS max_end_date,
   reason AS withdrawal_reason
 FROM
   ${ref(`ls_ecf_induction_lp_dedupe_start_decs`)} lp_dedupe
@@ -86,12 +76,7 @@ WHERE
   --# This looks at all inductions records and calculates the start date using the same logic above. This will enable us to slot the latest withdrawn induction record with a lead provider into the order of all induction records for a participant and identify their next induction record that occurred after their final induction record at the LP they were reported as withdrawn with.
   full_induction_records AS (
 SELECT
-  CASE
-    WHEN end_date IS NULL THEN DATE(start_date)
-    WHEN start_date < end_date THEN DATE(start_date)
-    ELSE DATE(end_date)
-END
-  AS next_start_date,
+  DATE(LEAST(COALESCE(end_date,start_date),start_date)) AS next_start_date,
   induction_record_id,
   inductions.participant_profile_id,
   inductions.induction_record_id AS next_id,
@@ -134,12 +119,12 @@ SELECT
 FROM
   withdrawn_participants_extended_training withdrawals
 LEFT JOIN
-  induction_periods ips
+  induction_periods
 ON
-  CAST(withdrawals.trn AS string) = ips.induction_trn
-  AND withdrawals.min_start_date < ips.finished_on_join
+  CAST(withdrawals.trn AS string) = induction_periods.induction_trn
+  AND withdrawals.min_start_date < induction_periods.finished_on_join
 QUALIFY
-  ROW_NUMBER() OVER (PARTITION BY lead_provider_name, participant_profile_id ORDER BY started_on ASC)=1),
+  ROW_NUMBER() OVER (PARTITION BY withdrawals.lead_provider_name, withdrawals.participant_profile_id ORDER BY started_on ASC)=1),
   --#This generates the associated boolean flags that identify if the common reasons reported for withdrawal by LPs are true or false for this particular record.
   withdrawn_participants_validated AS (
 SELECT


### PR DESCRIPTION
These marts enable contract managers to identify candidates for withdrawal and check whether withdrawn candidates have had the correct withdrawal reason provided.