### PR TITLE
Code abstraction, More DRY

### DIFF
--- a/definitions/marts/bigquery_marts/ecf2/ecf2_daily_snapshot_registrations.sqlx
+++ b/definitions/marts/bigquery_marts/ecf2/ecf2_daily_snapshot_registrations.sqlx
@@ -1,0 +1,55 @@
+config {
+    type: "table",
+    tags: ["ecf2"],
+    bigquery: {
+        partitionBy: "calendar_date",
+        clusterBy: ["school_id", "registration_window_year"]
+    },
+    description: "The total number of programme registrations, ect registrations and mentor registrations on a given date and registration window.",
+    columns: {
+        calendar_date: "Snapshot date. Based on the adjusted registration_date",
+        school_id: "The id of the school as in the ECF2 service",
+        registration_window_year: "Registration cohort year derived from the first school period. Using 1 June as the cutoff",
+        registrations: "Total number of registrations on that day per registration window.",
+        ect_registrations: "Total number of ECT registrations on that day per registration window.",
+        mentor_registrations: "Total number of Mentor registrations on that day per registration window."
+        }
+}
+
+
+
+WITH participant_registrations AS (
+  SELECT
+    adjusted_registration_date AS calendar_date,
+    school_id,
+    registration_window_year,
+    COUNT(DISTINCT teacher_id) AS registrations,
+    COUNT(DISTINCT CASE WHEN participant_type = 'ect' THEN teacher_id ELSE NULL END) AS ect_registrations,
+    COUNT(DISTINCT CASE WHEN participant_type = 'mentor' THEN teacher_id ELSE NULL END) AS mentor_registrations
+  FROM ${ref("ecf2_participant_registrations")}
+  GROUP BY 
+    adjusted_registration_date,
+    school_id,
+    registration_window_year
+)
+
+
+-- participants_registrations_pivot AS (
+--   SELECT *
+--   FROM participant_registrations
+--   PIVOT (
+--     SUM(registrations) AS total,
+--     SUM(ect_registrations) AS ect,
+--     SUM(mentor_registrations) AS mentor
+--     FOR registration_window_year IN (
+--       2021 AS reg_2021,
+--       2022 AS reg_2022, 
+--       2023 AS reg_2023, 
+--       2024 AS reg_2024, 
+--       2025 AS reg_2025, 
+--       2026 AS reg_2026
+--     )
+--   )
+-- )
+
+SELECT * FROM participant_registrations

--- a/definitions/marts/bigquery_marts/ecf2/ecf2_daily_snapshot_schools.sqlx
+++ b/definitions/marts/bigquery_marts/ecf2/ecf2_daily_snapshot_schools.sqlx
@@ -14,14 +14,14 @@ config {
         active_ects: "Number of distinct ECTs with an active school period on the snapshot date.",
         active_mentors: "Number of distinct mentors with an active school period on the snapshot date.",
 
-        first_programme_registrations: "Count of participants whose first ever programme registration occurred at this school on the snapshot date. Uses an adjusted created date.",
-        first_school_registrations: "Count of participants whose first registration at this school occurred on the snapshot date.Uses an adjusted created date.",
+        first_programme_starts: "Count of participants whose first ever programme started_on occurred at this school on the snapshot date.",
+        first_school_starts: "Count of participants whose first started_on at this school occurred on the snapshot date.",
 
-        first_school_ect_registrations: "Count of ECTs whose first registration at this school occurred on the snapshot date. Uses an adjusted created date.",
-        first_school_mentor_registrations: "Count of mentors whose first registration at this school occurred on the snapshot date. Uses an adjusted created date.",
+        first_school_ect_starts: "Count of ECTs whose first started_on at this school occurred on the snapshot date.",
+        first_school_mentor_starts: "Count of mentors whose first started_on at this school occurred on the snapshot date.",
 
-        first_programme_ect_registrations: "Count of ECTs whose first ever programme registration occurred at this school on the snapshot date. Uses an adjusted created date.",
-        first_programme_mentor_registrations: "Count of mentors whose first ever programme registration occurred at this school on the snapshot date.Uses an adjusted created date."
+        first_programme_ect_starts: "Count of ECTs whose first ever programme started_on occurred at this school on the snapshot date.",
+        first_programme_mentor_starts: "Count of mentors whose first ever programme started_on occurred at this school on the snapshot date."
 
         }
 }
@@ -122,26 +122,32 @@ school_daily_activity AS (
 ),
 
 
-first_programme_registrations AS (
+first_programme_starts AS (
   -- for each teacher and participant type:
-  -- get first overall registration
+  -- get first overall started_on
   SELECT
     teacher_id,
     participant_type,
     school_id,
 
-    CASE
-      WHEN EXTRACT(MONTH FROM started_on) >= 6
-      THEN EXTRACT(YEAR FROM started_on)
-      ELSE EXTRACT(YEAR FROM started_on) - 1
-    END AS registration_window_year,
+    -- CASE
+    --   WHEN EXTRACT(MONTH FROM started_on) >= 6
+    --   THEN EXTRACT(YEAR FROM started_on)
+    --   ELSE EXTRACT(YEAR FROM started_on) - 1
+    -- END AS registration_window_year,
 
-    CASE
-      WHEN EXTRACT(MONTH FROM started_on) >= 6
-       AND EXTRACT(MONTH FROM created_at) < 6
-      THEN DATE(EXTRACT(YEAR FROM created_at), 6, 1)
-      ELSE DATE(created_at)
-    END AS adjusted_registration_date
+    started_on AS first_programme_start
+
+    -- We can't use the "registration" logic in schools since
+    -- registrations can be done retrospectively (e.g., created in current reg window but started on in prior window)
+    -- which would break the logic of one record per day per school per registration 
+    -- (if the registration window is 1 June - 31 May)
+    -- CASE
+    --   WHEN EXTRACT(MONTH FROM started_on) >= 6
+    --    AND EXTRACT(MONTH FROM created_at) < 6
+    --   THEN DATE(EXTRACT(YEAR FROM created_at), 6, 1)
+    --   ELSE DATE(created_at)
+    -- END AS adjusted_registration_date
 
   FROM ${ref("ecf2_school_periods")}
   -- get the earliest row
@@ -155,16 +161,44 @@ first_programme_registrations AS (
 
 ),
 
+first_programme_starts_daily AS (
 
-participant_school_registrations AS (
+  SELECT
+    first_programme_start AS calendar_date,
+    school_id,
+    -- registration_window_year,
+
+    COUNT(DISTINCT teacher_id) AS first_programme_starts,
+
+    COUNT(DISTINCT CASE
+      WHEN participant_type = 'ect'
+      THEN teacher_id
+    END) AS first_programme_ect_starts,
+
+    COUNT(DISTINCT CASE
+      WHEN participant_type = 'mentor'
+      THEN teacher_id
+    END) AS first_programme_mentor_starts
+
+  FROM first_programme_starts
+
+  GROUP BY
+    calendar_date,
+    school_id
+    -- registration_window_year
+),
+
+
+
+participant_school_starts AS (
   -- for each teacher and participant type:
-  -- get first registration at school
+  -- get first started_on at school
   SELECT
     teacher_id,
     participant_type,
     school_id,
 
-    MIN(DATE(created_at)) AS actual_registration_date
+    MIN(DATE(started_on)) AS first_school_start
 
   FROM ${ref("ecf2_school_periods")}
 
@@ -175,25 +209,25 @@ participant_school_registrations AS (
 
 ),
 
-first_school_registration_daily AS (
-
+first_school_starts_daily AS (
+  -- get a count of ECTs, Mentors that started on a specific calendar date
   SELECT
-    actual_registration_date AS calendar_date,
+    first_school_start AS calendar_date,
     school_id,
 
-    COUNT(DISTINCT teacher_id) AS first_school_registrations,
+    COUNT(DISTINCT teacher_id) AS first_school_starts,
 
     COUNT(DISTINCT CASE
       WHEN participant_type = 'ect'
       THEN teacher_id
-    END) AS first_school_ect_registrations,
+    END) AS first_school_ect_starts,
 
     COUNT(DISTINCT CASE
       WHEN participant_type = 'mentor'
       THEN teacher_id
-    END) AS first_school_mentor_registrations
+    END) AS first_school_mentor_starts
 
-  FROM participant_school_registrations
+  FROM participant_school_starts
 
   GROUP BY
     calendar_date,
@@ -201,32 +235,26 @@ first_school_registration_daily AS (
 
 ),
 
-first_programme_registration_daily AS (
 
-  SELECT
-    adjusted_registration_date AS calendar_date,
-    school_id,
-    registration_window_year,
-
-    COUNT(DISTINCT teacher_id) AS first_programme_registrations,
-
-    COUNT(DISTINCT CASE
-      WHEN participant_type = 'ect'
-      THEN teacher_id
-    END) AS first_programme_ect_registrations,
-
-    COUNT(DISTINCT CASE
-      WHEN participant_type = 'mentor'
-      THEN teacher_id
-    END) AS first_programme_mentor_registrations
-
-  FROM first_programme_registrations
-
-  GROUP BY
-    calendar_date,
-    school_id,
-    registration_window_year
-
+participants_registrations_pivot AS (
+  SELECT *
+    -- for some reason has to be select * rather than selecting cols by name
+    -- calendar_date,
+    -- school_id
+  FROM ${ref("ecf2_daily_snapshot_registrations")}
+  PIVOT (
+    SUM(registrations) AS total,
+    SUM(ect_registrations) AS ect,
+    SUM(mentor_registrations) AS mentor
+    FOR registration_window_year IN (
+      2021 AS reg_2021,
+      2022 AS reg_2022, 
+      2023 AS reg_2023, 
+      2024 AS reg_2024, 
+      2025 AS reg_2025, 
+      2026 AS reg_2026
+    )
+  )
 ),
 
 
@@ -242,13 +270,32 @@ school_daily_snapshot AS (
     COALESCE(sd.active_school_periods, 0) AS active_school_periods,
     COALESCE(sd.active_ects, 0) AS active_ects,
     COALESCE(sd.active_mentors, 0) AS active_mentors,
-    COALESCE(prog_reg.first_programme_registrations, 0) AS first_programme_registrations,
-    COALESCE(prog_reg.first_programme_ect_registrations, 0) AS first_programme_ect_registrations,
-    COALESCE(prog_reg.first_programme_mentor_registrations, 0) AS first_programme_mentor_registrations,
+    COALESCE(prog_starts.first_programme_starts, 0) AS first_programme_starts,
+    COALESCE(prog_starts.first_programme_ect_starts, 0) AS first_programme_ect_starts,
+    COALESCE(prog_starts.first_programme_mentor_starts, 0) AS first_programme_mentor_starts,
 
-    COALESCE(school_reg.first_school_registrations, 0) AS first_school_registrations,
-    COALESCE(school_reg.first_school_ect_registrations, 0) AS first_school_ect_registrations,
-    COALESCE(school_reg.first_school_mentor_registrations, 0) AS first_school_mentor_registrations
+    COALESCE(school_starts.first_school_starts, 0) AS first_school_starts,
+    COALESCE(school_starts.first_school_ect_starts, 0) AS first_school_ect_starts,
+    COALESCE(school_starts.first_school_mentor_starts, 0) AS first_school_mentor_starts,
+
+    reg.total_reg_2021,
+    reg.total_reg_2022,
+    reg.total_reg_2023,
+    reg.total_reg_2024,
+    reg.total_reg_2025,
+    reg.total_reg_2026,
+    reg.ect_reg_2021,
+    reg.ect_reg_2022,
+    reg.ect_reg_2023,
+    reg.ect_reg_2024,
+    reg.ect_reg_2025,
+    reg.ect_reg_2026,
+    reg.mentor_reg_2021,
+    reg.mentor_reg_2022,
+    reg.mentor_reg_2023,
+    reg.mentor_reg_2024,
+    reg.mentor_reg_2025,
+    reg.mentor_reg_2026
 
 
   FROM school_base base
@@ -256,14 +303,17 @@ school_daily_snapshot AS (
     ON base.calendar_date = sd.calendar_date
     AND base.school_id = sd.school_id
   -- join the daily registrations to each school
-  LEFT JOIN first_school_registration_daily school_reg
-    ON base.calendar_date = school_reg.calendar_date
-    AND base.school_id = school_reg.school_id
+  LEFT JOIN first_school_starts_daily school_starts
+    ON base.calendar_date = school_starts.calendar_date
+    AND base.school_id = school_starts.school_id
 
-  LEFT JOIN first_programme_registration_daily prog_reg
-    ON base.calendar_date = prog_reg.calendar_date
-    AND base.school_id = prog_reg.school_id
-    AND base.registration_window_year = prog_reg.registration_window_year
+  LEFT JOIN first_programme_starts_daily prog_starts
+    ON base.calendar_date = prog_starts.calendar_date
+    AND base.school_id = prog_starts.school_id
+
+  LEFT JOIN participants_registrations_pivot reg
+    ON base.calendar_date = reg.calendar_date
+    AND base.school_id = reg.school_id
 --   ORDER BY
 --     base.calendar_date
 )

--- a/definitions/marts/bigquery_marts/ecf2/ecf2_daily_snapshot_teachers.sqlx
+++ b/definitions/marts/bigquery_marts/ecf2/ecf2_daily_snapshot_teachers.sqlx
@@ -111,31 +111,14 @@ participant_base AS (
   SELECT
     base.teacher_id,
     base.participant_type,
-    -- DATE(MIN(created_at)) AS registration_date,  -- Might have to adjust this if before 1 June
-    CASE
-      WHEN DATE(base.created_at) < DATE(EXTRACT(YEAR FROM base.created_at), 6, 1)
-        THEN DATE(EXTRACT(YEAR FROM base.created_at), 6, 1)
-      ELSE DATE(base.created_at)
-    END AS registration_date,  -- adjusted registration_date (if the created date is before 1 June, set it to June 1)
-
-    CASE
-      WHEN EXTRACT(MONTH FROM base.started_on) >= 6 THEN EXTRACT(YEAR FROM base.started_on)
-      ELSE EXTRACT(YEAR FROM base.started_on) - 1
-    END AS registration_window_year,
-    DATE(base.started_on) AS first_school_period_started_on,
+    base.adjusted_registration_date AS registration_date,
+    base.registration_window_year,
+    base.school_period_started_on AS first_school_period_started_on,
     lsp.last_school_period_finished_on
-  FROM ${ref("ecf2_school_periods")} base
+  FROM ${ref("ecf2_participant_registrations")} base
   LEFT JOIN latest_school_periods lsp
     ON lsp.teacher_id = base.teacher_id
     AND lsp.participant_type = base.participant_type
-  -- Take the first school_period for each teacher AND participant_type (this act as the point of registration)
-  QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY teacher_id, participant_type
-    ORDER BY
-      started_on,
-      created_at,
-      school_period_id
-  ) = 1
 ),
 
 

--- a/definitions/marts/bigquery_marts/ecf2/ecf2_participant_registrations.sqlx
+++ b/definitions/marts/bigquery_marts/ecf2/ecf2_participant_registrations.sqlx
@@ -1,0 +1,58 @@
+config {
+    type: "table",
+    tags: ["ecf2"],
+    bigquery: {
+        partitionBy: "adjusted_registration_date",
+        clusterBy: ["teacher_id", "participant_type", "registration_window_year"]
+    },
+    description: "A record per teacher / partiticpant type for the first school_period which serves as the point of registration. First school period identified by getting the earliest started_on date.",
+    columns: {
+        teacher_id: "Unique teacher identifier as assigned to the teacher in the ECf2 service.",
+        participant_type: "Participant role type: Must be ECT or Mentor.",
+        registration_window_year: "Registration cohort year derived from the first school period. Using 1 June as the cutoff",
+        registration_date: "Date the participant first registered in the programme. Derived from the created_at date of the first school_period.",
+        adjusted_registration_date: "The registration date adjusted to 1 June if the registration took place before the registration window formally opened. Used primarly for charting purposes.",
+        school_id: "The id of the first school",
+        first_school_period_started_on: "Start date of the participant's first school period."
+        }
+}
+
+
+
+WITH participant_registrations AS (
+  -- get the first ever school period for participants
+  -- use this as the first registration
+  SELECT
+    teacher_id,
+    participant_type,
+
+    -- get the registration year
+    CASE
+      WHEN EXTRACT(MONTH FROM started_on) >= 6 THEN EXTRACT(YEAR FROM started_on)
+      ELSE EXTRACT(YEAR FROM started_on) - 1
+    END AS registration_window_year,
+
+    -- get the registration date (from created at date)
+    DATE(created_at) AS registration_date,
+    CASE
+      WHEN DATE(created_at) < DATE(EXTRACT(YEAR FROM created_at), 6, 1)
+        THEN DATE(EXTRACT(YEAR FROM created_at), 6, 1)
+      ELSE DATE(created_at)
+    END AS adjusted_registration_date,  -- adjusted registration_date (if the created date is before 1 June, set it to June 1)
+    
+    school_id,
+    school_period_id AS school_period_id,
+    DATE(started_on) AS school_period_started_on
+    
+  FROM ${ref("ecf2_school_periods")}
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY teacher_id, participant_type
+    ORDER BY
+      started_on,
+      created_at,
+      school_period_id
+  ) = 1
+)
+
+
+SELECT * FROM participant_registrations


### PR DESCRIPTION
New table ecf2_participant_registration (referenced by snapshot tables - source of truth for registration - reusable)
New table ecf2_daily_snapshot_registrations (all registrations by date - more efficient to have separate)
Updated daily_snapshot_schools to read from tables rather than compute everything
Updated daily_snapshot_teachers to read from tables rather than compute everything