### PR TITLE
remove ORDER BY from tte_contract_management_2026

### DIFF
--- a/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026.sqlx
+++ b/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026.sqlx
@@ -21,4 +21,3 @@ SELECT
 
 FROM ${ref('tte_enrolments')}
 GROUP BY lead_provider_name, course_name
-ORDER BY lead_provider_name, course_name


### PR DESCRIPTION
fix: remove ORDER BY from tte_contract_management_2026 (having compatibility issues with the clustered tabes) 