### PR TITLE
add tte_contract_management_2026_flat and update ttte_contract_management_2026

### DIFF
--- a/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026.sqlx
+++ b/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026.sqlx
@@ -1,11 +1,32 @@
 -- This is the aggregated file that will be used to generate the NPD Contract manager dashboard
 -- It takes the flat data generated in tte_contract_management_2026_flat.sqlx
+-- NOTE That declarations are expected in October 2026
 
 config {
     type: "table",
     tags: ["tte"],
     bigquery: {
         clusterBy: ["lead_provider_name", "course_name"]
+    },
+    description: "This is the aggregated file that will be used to generate the NPD Contract manager dashboard. \n \
+    It takes the flat data generated in tte_contract_management_2026_flat.sqlx. \n \
+    It creates a table that outlines the number of applications, acceptance rates, and starts for each Lead Provider and their courses, filtered to the 2026-July cohort. \n",
+    columns: {
+        lead_provider_name: "Name of the lead provider.",
+        course_name: "Name of the course.",
+        total_applications: "Total number of applications.",
+        applications_eligible_for_funding: "Number of applications eligible for DfE funding.",
+        applications_not_eligible_for_funding: "Number of applications not eligible for DfE funding.",
+        total_unfunded_applications: "Number of applications not on a funded place.",
+        applications_pending: "Number of applications with a pending status.",
+        applications_accepted: "Number of applications with an accepted status.",
+        applications_rejected: "Number of applications with a rejected status.",
+        pct_pending: "Proportion of applications that are pending.",
+        pct_accepted: "Proportion of applications that are accepted.",
+        pct_rejected: "Proportion of applications that are rejected.",
+        applications_eligible_pending_or_accepted: "Number of applications eligible for DfE funding that are pending or accepted.",
+        applications_accepted_funded: "Number of applications accepted onto a funded place.",
+        applications_started_declaration_paid: "Number of applications with a started declaration that has been submitted, is eligible, payable, or paid on a funded place."
     }
 }
 

--- a/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026.sqlx
+++ b/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026.sqlx
@@ -1,3 +1,6 @@
+-- This is the aggregated file that will be used to generate the NPD Contract manager dashboard
+-- It takes the flat data generated in tte_contract_management_2026_flat.sqlx
+
 config {
     type: "table",
     tags: ["tte"],
@@ -9,15 +12,38 @@ config {
 SELECT
     lead_provider_name,
     course_name,
-    COUNT(DISTINCT application_id) AS total_applications,
-    COUNT(DISTINCT CASE WHEN application_status = 'accepted' THEN application_id END) AS applications_accepted,
-    COUNT(DISTINCT CASE WHEN application_status = 'withdrawn' THEN application_id END) AS applications_withdrawn,
-    COUNT(DISTINCT CASE WHEN application_status = 'started' THEN application_id END) AS applications_started,
-    COUNT(DISTINCT CASE WHEN application_status = 'rejected' THEN application_id END) AS applications_rejected,
-    COUNT(DISTINCT CASE WHEN application_status = 'completed' THEN application_id END) AS applications_completed,
-    COUNT(DISTINCT CASE WHEN application_status = 'deferred' THEN application_id END) AS applications_deferred,
-    COUNT(CASE WHEN declaration_type = 'started' AND declaration_state IN ('submitted', 'eligible', 'payable', 'paid') THEN declaration_id END) AS declarations_type_started,
-    COUNT(CASE WHEN declaration_type = 'completed' AND declaration_state IN ('submitted', 'eligible', 'payable', 'paid') THEN declaration_id END) AS declarations_type_completed
 
-FROM ${ref('tte_enrolments')}
+    -- Headline figures
+    COUNT(DISTINCT application_id)                                                                          AS total_applications,
+    COUNT(DISTINCT CASE WHEN eligible_for_funding = TRUE THEN application_id END)                          AS applications_eligible_for_funding,
+    COUNT(DISTINCT CASE WHEN eligible_for_funding = FALSE THEN application_id END)                         AS applications_not_eligible_for_funding,
+    COUNT(DISTINCT CASE WHEN funded_place = FALSE OR funded_place IS NULL THEN application_id END)         AS total_unfunded_applications,
+
+    -- Applications by status
+    COUNT(DISTINCT CASE WHEN application_status = 'pending' THEN application_id END)                      AS applications_pending,
+    COUNT(DISTINCT CASE WHEN application_status = 'accepted' THEN application_id END)                     AS applications_accepted,
+    COUNT(DISTINCT CASE WHEN application_status = 'rejected' THEN application_id END)                     AS applications_rejected,
+
+    -- Percentages
+    ROUND(SAFE_DIVIDE(
+        COUNT(DISTINCT CASE WHEN application_status = 'pending' THEN application_id END),
+        COUNT(DISTINCT application_id)) * 100, 2)                                                         AS pct_pending,
+    ROUND(SAFE_DIVIDE(
+        COUNT(DISTINCT CASE WHEN application_status = 'accepted' THEN application_id END),
+        COUNT(DISTINCT application_id)) * 100, 2)                                                         AS pct_accepted,
+    ROUND(SAFE_DIVIDE(
+        COUNT(DISTINCT CASE WHEN application_status = 'rejected' THEN application_id END),
+        COUNT(DISTINCT application_id)) * 100, 2)                                                         AS pct_rejected,
+
+    -- Pivot table 1 — eligible, pending or accepted
+    COUNT(DISTINCT CASE WHEN flag_eligible_pending_or_accepted = TRUE THEN application_id END)            AS applications_eligible_pending_or_accepted,
+
+    -- Pivot table 2 — accepted onto funded place
+    COUNT(DISTINCT CASE WHEN flag_accepted_funded = TRUE THEN application_id END)                         AS applications_accepted_funded,
+
+    -- Pivot table 3 — started declaration paid
+    COUNT(DISTINCT CASE WHEN flag_started_declaration_paid = TRUE THEN application_id END)                AS applications_started_declaration_paid
+
+FROM ${ref('tte_contract_management_2026_flat')}
 GROUP BY lead_provider_name, course_name
+ORDER BY lead_provider_name, course_name

--- a/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026_flat.sqlx
+++ b/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026_flat.sqlx
@@ -6,8 +6,51 @@ config {
     bigquery: {
         partitionBy: "DATE(application_created_at)",
         clusterBy: ["lead_provider_name", "course_name", "application_status"]
+    },
+    description: "This mart is made to assist TTE Contract Managers with Lead Provider conversations related to the 2026 cohort beginning in July 2026. \n \
+    It creates a flat table of applications filtered to the 2026-July cohort, including funding, provider, course, institution, declaration, and participant outcome dimensions. \n \
+    This table does not contain aggregated counts or financial allocation data — use tte_contract_management_2026 for pre-aggregated figures. \n",
+    columns: {
+        application_id: "Unique ID for the application.",
+        application_ecf_id: "ECF ID for the application.",
+        application_status: "Status of the application. Can be pending, accepted, or rejected.",
+        application_created_at: "When the application was created.",
+        application_updated_at: "When the application was last updated.",
+        eligible_for_funding: "Whether the application is eligible for DfE funding.",
+        funded_place: "Whether the application has been accepted onto a funded place.",
+        funding_choice: "How the participant intends to fund their training. Can be school, trust, or self.",
+        funding_eligiblity_status_code: "Funding eligibility status code.",
+        targeted_support_funding_eligibility: "Whether the application is eligible for targeted support funding.",
+        lead_provider_name: "Name of the lead provider.",
+        lead_provider_ecf_id: "ECF ID for the lead provider.",
+        course_name: "Name of the course.",
+        course_identifier: "Course identifier.",
+        course_short_code: "Shortened course code.",
+        course_group: "Course group.",
+        cohort_identifier: "Cohort identifier e.g. 2026-July.",
+        cohort_start_year: "Year the cohort starts.",
+        schedule_name: "Name of the schedule.",
+        schedule_training_starts_at: "When training starts.",
+        schedule_training_ends_at: "When training ends.",
+        institution_name: "Name of the institution.",
+        institutionable_type: "Type of institution.",
+        region: "Region of the institution.",
+        la_name: "Local authority name.",
+        phase_name: "School phase.",
+        establishment_type_name: "Type of school establishment.",
+        high_pupil_premium: "Whether the school has high pupil premium.",
+        -- NOTE Declarations are expected Octover 2026
+        declaration_type: "Type of declaration e.g. started, completed.",
+        declaration_state: "State of the declaration e.g. submitted, eligible, payable, paid.",
+        declaration_date: "Date of the declaration.",
+        participant_outcome_state_result: "Outcome state for the participant.",
+        participant_outcome_completion_date: "Date the participant outcome was completed.",
+        flag_eligible_pending_or_accepted: "True where the application is eligible for DfE funding and is pending or accepted.",
+        flag_accepted_funded: "True where the application has been accepted onto a funded place.",
+        flag_started_declaration_paid: "True where a started declaration has been submitted, is eligible, payable, or paid on a funded place."
     }
 }
+
 
 SELECT
     -- Application

--- a/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026_flat.sqlx
+++ b/definitions/marts/looker_studio_marts/tte/tte_contract_management_2026_flat.sqlx
@@ -1,0 +1,78 @@
+-- This is the flat file that will be used to generate tte_contract_management_2026.sqlx
+
+config {
+    type: "table",
+    tags: ["tte"],
+    bigquery: {
+        partitionBy: "DATE(application_created_at)",
+        clusterBy: ["lead_provider_name", "course_name", "application_status"]
+    }
+}
+
+SELECT
+    -- Application
+    application_id,
+    application_ecf_id,
+    application_status,
+    application_created_at,
+    application_updated_at,
+
+    -- Funding
+    eligible_for_funding,
+    funded_place,
+    funding_choice,
+    funding_eligiblity_status_code,
+    targeted_support_funding_eligibility,
+
+    -- Provider
+    lead_provider_name,
+    lead_provider_ecf_id,
+
+    -- Course
+    course_name,
+    course_identifier,
+    course_short_code,
+    course_group,
+
+    -- Cohort
+    cohort_identifier,
+    cohort_start_year,
+
+    -- Schedule
+    schedule_name,
+    schedule_training_starts_at,
+    schedule_training_ends_at,
+
+    -- Institution
+    institution_name,
+    institutionable_type,
+    region,
+
+    -- School
+    la_name,
+    phase_name,
+    establishment_type_name,
+    high_pupil_premium,
+
+    -- Declaration
+    declaration_type,
+    declaration_state,
+    declaration_date,
+
+    -- Participant outcome
+    participant_outcome_state_result,
+    participant_outcome_completion_date,
+
+    -- Flags
+    eligible_for_funding = TRUE
+    AND application_status IN ('pending', 'accepted') AS flag_eligible_pending_or_accepted,
+
+    application_status = 'accepted'
+    AND funded_place = TRUE AS flag_accepted_funded,
+
+    funded_place = TRUE
+    AND declaration_type = 'started'
+    AND declaration_state IN ('submitted', 'eligible', 'payable', 'paid')   AS flag_started_declaration_paid
+
+FROM ${ref('tte_enrolments')}
+WHERE cohort_identifier = '2026-July'


### PR DESCRIPTION
Adds a flat looker mart for TTE contract management 2026 and updates ttte_contract_management_2026 to build on top to allow looker aggregations (and also thinking ahead to the NPD NPQ merge)

tte_contract_management_2026_flat.sqlx
Row per application, filtered to July 2026 cohort.

tte_contract_management_2026.sqlx
Now references the flat mart and allows metrics to mirror the NPQ Contract Management Dashboard. 